### PR TITLE
Fix/#73 year dropdown

### DIFF
--- a/apps/client/src/features/goals/EntryCreatePage.tsx
+++ b/apps/client/src/features/goals/EntryCreatePage.tsx
@@ -45,7 +45,7 @@ const EntryForm: React.FC<EntryFormProps> = ({
 }) => {
   const navigate = useNavigate()
 
-  const currentYear = useCurrentYear();
+  const currentYear = useCurrentYear()
   const entryDatePlaceholder = `e.g. 01 January ${currentYear}`
 
   const initialValues = defaultValues

--- a/apps/client/src/features/goals/EntryCreatePage.tsx
+++ b/apps/client/src/features/goals/EntryCreatePage.tsx
@@ -24,6 +24,7 @@ import {
 } from '@/components/custom/ErrorComponents'
 import { capitalizeFirstLetter } from '@/lib/stringUtils'
 import { Button } from '@/components/ui/button'
+import { useCurrentYear } from '@/hooks/useCurrentDate'
 
 interface EntryFormProps {
   isCreate: boolean
@@ -43,6 +44,9 @@ const EntryForm: React.FC<EntryFormProps> = ({
   defaultValues,
 }) => {
   const navigate = useNavigate()
+
+  const currentYear = useCurrentYear();
+  const entryDatePlaceholder = `e.g. 01 January ${currentYear}`
 
   const initialValues = defaultValues
     ? {
@@ -150,7 +154,7 @@ const EntryForm: React.FC<EntryFormProps> = ({
       >
         <form.AppField name="entryDate">
           {(field) => (
-            <field.DateField label="Date" placeholder="e.g. 11 July 2025" />
+            <field.DateField label="Date" placeholder={entryDatePlaceholder} />
           )}
         </form.AppField>
 

--- a/apps/client/src/features/goals/GoalDetailsPage.tsx
+++ b/apps/client/src/features/goals/GoalDetailsPage.tsx
@@ -16,14 +16,16 @@ import type { GoalStatisticsReponse } from '@habit-tracker/validation-schemas'
 import IconButton from '@/components/custom/IconButton'
 import { TopBarBack } from '@/components/custom/TopBar'
 import { ErrorBodyComponent } from '@/components/custom/ErrorComponents'
+import { useCurrentDate } from '@/hooks/useCurrentDate'
 
 export const GoalDetailsPage = () => {
   const navigate = useNavigate()
   const route = getRouteApi('/goals_/$goalId')
 
   // TODOs #12 Improve loading display + error display
+  const currentYear = useCurrentDate().getFullYear()
   const { goalId } = route.useParams()
-  const [selectedYear, setSelectedYear] = useState<number>(2025)
+  const [selectedYear, setSelectedYear] = useState<number>(currentYear)
 
   // Un-used variables to be addressed in #12
   /* eslint-disable @typescript-eslint/no-unused-vars */

--- a/apps/client/src/features/goals/GoalsPage.tsx
+++ b/apps/client/src/features/goals/GoalsPage.tsx
@@ -13,11 +13,13 @@ import { EmptyStateBodyComponent } from '@/components/custom/EmptyStateComponent
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import DropdownMenuOptions from '@/components/custom/DropdownMenuOptions'
 import { useLogoutUserMutation } from '@/apis/UserApi'
+import { useCurrentYear } from '@/hooks/useCurrentDate'
 
 // TODOs #17: investigate if lazy loading will help with initial render speed of goals page
 export const GoalsPage = () => {
   const navigate = useNavigate()
-  const [selectedYear, setSelectedYear] = useState<number>(2025)
+  const currentYear = useCurrentYear();
+  const [selectedYear, setSelectedYear] = useState<number>(currentYear)
 
   const { data, isLoading, error } = useGoals()
   const displayedData = data

--- a/apps/client/src/features/goals/GoalsPage.tsx
+++ b/apps/client/src/features/goals/GoalsPage.tsx
@@ -18,7 +18,7 @@ import { useCurrentYear } from '@/hooks/useCurrentDate'
 // TODOs #17: investigate if lazy loading will help with initial render speed of goals page
 export const GoalsPage = () => {
   const navigate = useNavigate()
-  const currentYear = useCurrentYear();
+  const currentYear = useCurrentYear()
   const [selectedYear, setSelectedYear] = useState<number>(currentYear)
 
   const { data, isLoading, error } = useGoals()

--- a/apps/client/src/features/goals/components/EntryCalendar.tsx
+++ b/apps/client/src/features/goals/components/EntryCalendar.tsx
@@ -11,6 +11,7 @@ import type {
 } from '@habit-tracker/validation-schemas'
 import { Calendar } from '@/components/ui/calendar'
 import { computeBinAndColorArrays } from '@/lib/colourUtils'
+import { useCurrentDate } from '@/hooks/useCurrentDate'
 
 /**
  * Modifier config, for grouping modifier-related properties
@@ -32,9 +33,8 @@ const EntryCalendar: React.FC<EntryCalendarProps> = ({
 }) => {
   const navigate = useNavigate()
 
-  const [date, setDate] = React.useState<Date | undefined>(
-    new Date(2025, 6, 12),
-  )
+  const currentDate = useCurrentDate();
+  const [date, setDate] = React.useState<Date | undefined>(currentDate)
 
   const { data: goalData } = useGoal(goalId.toString())
   const { data: entriesData } = useGoalEntries(searchParams)

--- a/apps/client/src/features/goals/components/EntryCalendar.tsx
+++ b/apps/client/src/features/goals/components/EntryCalendar.tsx
@@ -33,7 +33,7 @@ const EntryCalendar: React.FC<EntryCalendarProps> = ({
 }) => {
   const navigate = useNavigate()
 
-  const currentDate = useCurrentDate();
+  const currentDate = useCurrentDate()
   const [date, setDate] = React.useState<Date | undefined>(currentDate)
 
   const { data: goalData } = useGoal(goalId.toString())

--- a/apps/client/src/features/goals/components/YearDropdown.tsx
+++ b/apps/client/src/features/goals/components/YearDropdown.tsx
@@ -12,16 +12,17 @@ const YearDropdown: React.FC<YearDropdownProps> = ({
   selectedYear,
   onSelect,
 }) => {
-  const startYear = 2024;
-  const currentYear = useCurrentYear();
-  const yearMenuConfig: Array<DropdownMenuCheckboxesItemConfig<number>> = Array.from({ length: currentYear - startYear + 1 }, (_, i) => {
-    const yearValue = startYear + i;
-    return {
-      label: `Y${yearValue}`,
-      value: yearValue,
-    }
-  });
-  
+  const startYear = 2024
+  const currentYear = useCurrentYear()
+  const yearMenuConfig: Array<DropdownMenuCheckboxesItemConfig<number>> =
+    Array.from({ length: currentYear - startYear + 1 }, (_, i) => {
+      const yearValue = startYear + i
+      return {
+        label: `Y${yearValue}`,
+        value: yearValue,
+      }
+    })
+
   return (
     <div className="year-calendar-container flex flex-row gap-1">
       <h2 className="text-xl font-bold">{selectedYear}</h2>

--- a/apps/client/src/features/goals/components/YearDropdown.tsx
+++ b/apps/client/src/features/goals/components/YearDropdown.tsx
@@ -1,6 +1,7 @@
 import type { DropdownMenuCheckboxesItemConfig } from '@/components/custom/DropdownMenuCheckboxes'
 import DropdownMenuCheckboxes from '@/components/custom/DropdownMenuCheckboxes'
 import IconButton from '@/components/custom/IconButton'
+import { useCurrentYear } from '@/hooks/useCurrentDate'
 
 interface YearDropdownProps {
   selectedYear: number
@@ -11,11 +12,16 @@ const YearDropdown: React.FC<YearDropdownProps> = ({
   selectedYear,
   onSelect,
 }) => {
-  const yearMenuConfig: Array<DropdownMenuCheckboxesItemConfig<number>> = [
-    { label: '2025', value: 2025 },
-    { label: '2024', value: 2024 },
-  ]
-
+  const startYear = 2024;
+  const currentYear = useCurrentYear();
+  const yearMenuConfig: Array<DropdownMenuCheckboxesItemConfig<number>> = Array.from({ length: currentYear - startYear + 1 }, (_, i) => {
+    const yearValue = startYear + i;
+    return {
+      label: `Y${yearValue}`,
+      value: yearValue,
+    }
+  });
+  
   return (
     <div className="year-calendar-container flex flex-row gap-1">
       <h2 className="text-xl font-bold">{selectedYear}</h2>

--- a/apps/client/src/features/profile/ProfilePage.tsx
+++ b/apps/client/src/features/profile/ProfilePage.tsx
@@ -11,12 +11,14 @@ import { useProfile, useProfileGoals } from '@/apis/ProfileApi'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 
 import { TopBarConfig } from '@/components/custom/TopBar'
+import { useCurrentYear } from '@/hooks/useCurrentDate'
 
 export const ProfilePage = () => {
   const navigate = useNavigate()
   const route = getRouteApi('/profile_/$profileName')
 
-  const [selectedYear, setSelectedYear] = useState<number>(2025)
+  const currentYear = useCurrentYear()
+  const [selectedYear, setSelectedYear] = useState<number>(currentYear)
 
   const { profileName } = route.useParams()
 

--- a/apps/client/src/hooks/useCurrentDate.ts
+++ b/apps/client/src/hooks/useCurrentDate.ts
@@ -1,0 +1,14 @@
+import { useState } from 'react'
+
+export function useCurrentDate({ tz = 'UTC' } = {}) {
+  const [currentDate] = useState(new Date());
+
+  // Returns date adjusted to timezone
+  const tzDate = new Date(currentDate.toLocaleString('en-US', { timeZone: tz }));
+  return tzDate;
+}
+
+export function useCurrentYear({ tz = 'UTC' } = {}) {
+  const currentDate = useCurrentDate({ tz: tz })
+  return currentDate.getFullYear();
+}

--- a/apps/client/src/hooks/useCurrentDate.ts
+++ b/apps/client/src/hooks/useCurrentDate.ts
@@ -1,14 +1,14 @@
 import { useState } from 'react'
 
 export function useCurrentDate({ tz = 'UTC' } = {}) {
-  const [currentDate] = useState(new Date());
+  const [currentDate] = useState(new Date())
 
   // Returns date adjusted to timezone
-  const tzDate = new Date(currentDate.toLocaleString('en-US', { timeZone: tz }));
-  return tzDate;
+  const tzDate = new Date(currentDate.toLocaleString('en-US', { timeZone: tz }))
+  return tzDate
 }
 
 export function useCurrentYear({ tz = 'UTC' } = {}) {
   const currentDate = useCurrentDate({ tz: tz })
-  return currentDate.getFullYear();
+  return currentDate.getFullYear()
 }


### PR DESCRIPTION
Added new hook `useCurrentDate` to capture logic of determining current date (and year) to use for year dropdown options.