### PR TITLE
Feature/#42 user context

### DIFF
--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -4,7 +4,8 @@ import * as bcrypt from 'bcrypt';
 import { UsersService } from '../users/users.service';
 import { JwtService } from '@nestjs/jwt';
 import { UserResponseDto } from '@habit-tracker/validation-schemas';
-import { JwtPayload } from './jwt-auth.types';
+import { JwtPayload, JwtRequestUser } from './jwt-auth.types';
+import { mapUserPrismaModelToDto } from 'src/users/users.mapping';
 
 @Injectable()
 export class AuthService {
@@ -16,7 +17,7 @@ export class AuthService {
   async validateUser(
     email: string,
     password: string,
-  ): Promise<UserResponseDto | null> {
+  ): Promise<JwtRequestUser | null> {
     const user = await this.usersService.findOneByEmailFull(email);
     const passwordValid = user
       ? await bcrypt.compare(password, user.password)
@@ -35,7 +36,7 @@ export class AuthService {
    * @param user - user to generate JWT with
    * @returns - obj with `access_token`
    */
-  login(user: UserResponseDto) {
+  login(user: JwtRequestUser) {
     const payload: JwtPayload = {
       email: user.email,
       username: user.username,

--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -3,9 +3,7 @@ import * as bcrypt from 'bcrypt';
 
 import { UsersService } from '../users/users.service';
 import { JwtService } from '@nestjs/jwt';
-import { UserResponseDto } from '@habit-tracker/validation-schemas';
 import { JwtPayload, JwtRequestUser } from './jwt-auth.types';
-import { mapUserPrismaModelToDto } from 'src/users/users.mapping';
 
 @Injectable()
 export class AuthService {

--- a/apps/backend/src/auth/local.strategy.ts
+++ b/apps/backend/src/auth/local.strategy.ts
@@ -2,7 +2,6 @@ import { Strategy } from 'passport-local';
 import { PassportStrategy } from '@nestjs/passport';
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { AuthService } from './auth.service';
-import { UserResponseDto } from '@habit-tracker/validation-schemas';
 import { JwtRequestUser } from './jwt-auth.types';
 
 /**

--- a/apps/backend/src/auth/local.strategy.ts
+++ b/apps/backend/src/auth/local.strategy.ts
@@ -3,6 +3,7 @@ import { PassportStrategy } from '@nestjs/passport';
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { UserResponseDto } from '@habit-tracker/validation-schemas';
+import { JwtRequestUser } from './jwt-auth.types';
 
 /**
  * Local-type Passport strategy.
@@ -19,7 +20,7 @@ export class LocalStrategy extends PassportStrategy(Strategy) {
   async validate(
     email: string,
     password: string,
-  ): Promise<UserResponseDto | null> {
+  ): Promise<JwtRequestUser | null> {
     const user = await this.authService.validateUser(email, password);
     if (!user) {
       throw new UnauthorizedException();

--- a/apps/backend/src/users/users.controller.ts
+++ b/apps/backend/src/users/users.controller.ts
@@ -16,6 +16,7 @@ import {
   CreateUserSchema,
   UpdateUserSchema,
   UserResponseDto,
+  ProfilePublicityType,
 } from '@habit-tracker/validation-schemas';
 import {
   ApiBearerAuth,
@@ -42,6 +43,9 @@ class UserResponseDtoClass implements UserResponseDto {
 
   @ApiProperty({ example: 'alice@alice.com' })
   email: string;
+
+  @ApiProperty({ example: ProfilePublicityType.Public })
+  profilePublicity: ProfilePublicityType;
 }
 
 class CreateUserDtoClass implements CreateUserDto {

--- a/apps/backend/src/users/users.mapping.ts
+++ b/apps/backend/src/users/users.mapping.ts
@@ -2,15 +2,24 @@
  * User object mapping helpers
  */
 
-import { ProfilePublicityType, UserResponseDto } from "@habit-tracker/validation-schemas";
-import { $Enums, User } from "@prisma/client";
+import {
+  ProfilePublicityType,
+  UserResponseDto,
+} from '@habit-tracker/validation-schemas';
+import { $Enums, User } from '@prisma/client';
 
-export const PROFILE_PUBLICITY_ENUM_TO_TYPE: Record<$Enums.ProfilePublicity, ProfilePublicityType> = {
+export const PROFILE_PUBLICITY_ENUM_TO_TYPE: Record<
+  $Enums.ProfilePublicity,
+  ProfilePublicityType
+> = {
   [$Enums.ProfilePublicity.PRIVATE]: ProfilePublicityType.Private,
   [$Enums.ProfilePublicity.PUBLIC]: ProfilePublicityType.Public,
 };
 
-export const PROFILE_PUBLICITY_TYPE_TO_ENUM: Record<ProfilePublicityType, $Enums.ProfilePublicity> = {
+export const PROFILE_PUBLICITY_TYPE_TO_ENUM: Record<
+  ProfilePublicityType,
+  $Enums.ProfilePublicity
+> = {
   [ProfilePublicityType.Private]: $Enums.ProfilePublicity.PRIVATE,
   [ProfilePublicityType.Public]: $Enums.ProfilePublicity.PUBLIC,
 };
@@ -20,12 +29,15 @@ export function mapUserPrismaModelToDto(userPrisma: User): UserResponseDto {
     id: userPrisma.id,
     username: userPrisma.username,
     email: userPrisma.email,
-    profilePublicity: PROFILE_PUBLICITY_ENUM_TO_TYPE[userPrisma.profilePublicity]
+    profilePublicity:
+      PROFILE_PUBLICITY_ENUM_TO_TYPE[userPrisma.profilePublicity],
   };
   return userResponse;
 }
 
-export function mapUserPrismaModelOrNullToDto(userPrisma: User | null): UserResponseDto | null {
+export function mapUserPrismaModelOrNullToDto(
+  userPrisma: User | null,
+): UserResponseDto | null {
   if (userPrisma === null) {
     return null;
   }

--- a/apps/backend/src/users/users.mapping.ts
+++ b/apps/backend/src/users/users.mapping.ts
@@ -1,0 +1,29 @@
+/**
+ * User object mapping helpers
+ */
+
+import { ProfilePublicityType, UserResponseDto } from "@habit-tracker/validation-schemas";
+import { $Enums, User } from "@prisma/client";
+
+const PROFILE_PUBLICITY_ENUM_TO_TYPE: Record<$Enums.ProfilePublicity, ProfilePublicityType> = {
+  [$Enums.ProfilePublicity.PRIVATE]: ProfilePublicityType.Private,
+  [$Enums.ProfilePublicity.PUBLIC]: ProfilePublicityType.Public,
+};
+
+export function mapUserPrismaModelToDto(userPrisma: User): UserResponseDto {
+  const userResponse: UserResponseDto = {
+    id: userPrisma.id,
+    username: userPrisma.username,
+    email: userPrisma.email,
+    profilePublicity: PROFILE_PUBLICITY_ENUM_TO_TYPE[userPrisma.profilePublicity]
+  };
+  return userResponse;
+}
+
+export function mapUserPrismaModelOrNullToDto(userPrisma: User | null): UserResponseDto | null {
+  if (userPrisma === null) {
+    return null;
+  }
+
+  return mapUserPrismaModelToDto(userPrisma);
+}

--- a/apps/backend/src/users/users.mapping.ts
+++ b/apps/backend/src/users/users.mapping.ts
@@ -5,9 +5,14 @@
 import { ProfilePublicityType, UserResponseDto } from "@habit-tracker/validation-schemas";
 import { $Enums, User } from "@prisma/client";
 
-const PROFILE_PUBLICITY_ENUM_TO_TYPE: Record<$Enums.ProfilePublicity, ProfilePublicityType> = {
+export const PROFILE_PUBLICITY_ENUM_TO_TYPE: Record<$Enums.ProfilePublicity, ProfilePublicityType> = {
   [$Enums.ProfilePublicity.PRIVATE]: ProfilePublicityType.Private,
   [$Enums.ProfilePublicity.PUBLIC]: ProfilePublicityType.Public,
+};
+
+export const PROFILE_PUBLICITY_TYPE_TO_ENUM: Record<ProfilePublicityType, $Enums.ProfilePublicity> = {
+  [ProfilePublicityType.Private]: $Enums.ProfilePublicity.PRIVATE,
+  [ProfilePublicityType.Public]: $Enums.ProfilePublicity.PUBLIC,
 };
 
 export function mapUserPrismaModelToDto(userPrisma: User): UserResponseDto {

--- a/apps/backend/src/users/users.service.ts
+++ b/apps/backend/src/users/users.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { Prisma, User } from '@prisma/client';
+import { Prisma, User, ProfilePublicity, $Enums } from '@prisma/client';
 import * as bcrypt from 'bcrypt';
 
 import { PrismaService } from '../prisma/prisma.service';
@@ -16,11 +16,13 @@ import {
 import { UserNotFoundError } from './errors/userNotFound.error';
 import { UserPasswordInputInvalidError } from './errors/userPasswordInputInvalid.error';
 import { UserAlreadyExistsError } from './errors/userAlreadyExists.error';
+import { mapUserPrismaModelOrNullToDto, mapUserPrismaModelToDto } from './users.mapping';
 
 export const userResponseSelect: Prisma.UserSelect = {
   id: true,
   username: true,
   email: true,
+  profilePublicity: true,
 };
 
 @Injectable()
@@ -29,7 +31,6 @@ export class UsersService {
     private prisma: PrismaService,
     private envService: EnvService,
   ) {}
-
   async create(createUserDto: CreateUserDto): Promise<UserResponseDto> {
     const hashedPassword = await bcrypt.hash(
       createUserDto.password,
@@ -41,10 +42,11 @@ export class UsersService {
       password: hashedPassword,
     };
     try {
-      return await this.prisma.user.create({
+      const userModel = await this.prisma.user.create({
         data: prismaInput,
         select: userResponseSelect,
       });
+      return mapUserPrismaModelToDto(userModel);
     } catch (error) {
       if (error instanceof Prisma.PrismaClientKnownRequestError) {
         if (
@@ -61,25 +63,31 @@ export class UsersService {
     }
   }
 
-  findOne(id: number): Promise<UserResponseDto | null> {
-    return this.prisma.user.findUnique({
-      where: { id },
-      select: userResponseSelect,
-    });
+    findOne(id: number): Promise<UserResponseDto | null> {
+    return this.prisma.user
+      .findUnique({
+        where: { id },
+        select: userResponseSelect,
+      })
+      .then(mapUserPrismaModelOrNullToDto);
   }
 
   findOneByUsername(username: string): Promise<UserResponseDto | null> {
-    return this.prisma.user.findUnique({
-      where: { username },
-      select: userResponseSelect,
-    });
+    return this.prisma.user
+      .findUnique({
+        where: { username },
+        select: userResponseSelect,
+      })
+      .then(mapUserPrismaModelOrNullToDto);
   }
 
   findOneByEmail(email: string): Promise<UserResponseDto | null> {
-    return this.prisma.user.findUnique({
-      where: { email },
-      select: userResponseSelect,
-    });
+    return this.prisma.user
+      .findUnique({
+        where: { email },
+        select: userResponseSelect,
+      })
+      .then(mapUserPrismaModelOrNullToDto);
   }
 
   findOneByEmailFull(email: string): Promise<User | null> {
@@ -120,11 +128,12 @@ export class UsersService {
       password: hashedPassword,
     };
     try {
-      return await this.prisma.user.update({
+      const userModel = await this.prisma.user.update({
         where: { id },
         data: prismaInput,
         select: userResponseSelect,
       });
+      return mapUserPrismaModelToDto(userModel);
     } catch (error) {
       if (error instanceof Prisma.PrismaClientKnownRequestError) {
         if (
@@ -141,10 +150,11 @@ export class UsersService {
     }
   }
 
-  remove(id: number) {
+  remove(id: number): Promise<UserResponseDto> {
     return this.prisma.user.delete({
       where: { id },
       select: userResponseSelect,
-    });
+    })
+    .then(mapUserPrismaModelToDto);
   }
 }

--- a/apps/backend/src/users/users.service.ts
+++ b/apps/backend/src/users/users.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { Prisma, User, ProfilePublicity, $Enums } from '@prisma/client';
+import { Prisma, User } from '@prisma/client';
 import * as bcrypt from 'bcrypt';
 
 import { PrismaService } from '../prisma/prisma.service';
@@ -16,7 +16,11 @@ import {
 import { UserNotFoundError } from './errors/userNotFound.error';
 import { UserPasswordInputInvalidError } from './errors/userPasswordInputInvalid.error';
 import { UserAlreadyExistsError } from './errors/userAlreadyExists.error';
-import { mapUserPrismaModelOrNullToDto, mapUserPrismaModelToDto, PROFILE_PUBLICITY_TYPE_TO_ENUM } from './users.mapping';
+import {
+  mapUserPrismaModelOrNullToDto,
+  mapUserPrismaModelToDto,
+  PROFILE_PUBLICITY_TYPE_TO_ENUM,
+} from './users.mapping';
 
 export const userResponseSelect: Prisma.UserSelect = {
   id: true,
@@ -63,7 +67,7 @@ export class UsersService {
     }
   }
 
-    findOne(id: number): Promise<UserResponseDto | null> {
+  findOne(id: number): Promise<UserResponseDto | null> {
     return this.prisma.user
       .findUnique({
         where: { id },
@@ -109,16 +113,22 @@ export class UsersService {
     }
 
     // Require current password for sensitive updates (username, email, password)
-    const requiresPassword = updateUserDto.username !== undefined ||
-                             updateUserDto.email !== undefined ||
-                             updateUserDto.password !== undefined;
+    const requiresPassword =
+      updateUserDto.username !== undefined ||
+      updateUserDto.email !== undefined ||
+      updateUserDto.password !== undefined;
 
     let passwordValid = true;
     if (requiresPassword) {
       if (!updateUserDto.currentPassword) {
-        throw new UserPasswordInputInvalidError('Current password is required for this update');
+        throw new UserPasswordInputInvalidError(
+          'Current password is required for this update',
+        );
       }
-      passwordValid = await bcrypt.compare(updateUserDto.currentPassword, user.password);
+      passwordValid = await bcrypt.compare(
+        updateUserDto.currentPassword,
+        user.password,
+      );
     }
     if (!passwordValid) {
       throw new UserPasswordInputInvalidError('Invalid current password');
@@ -142,7 +152,8 @@ export class UsersService {
       prismaInput.password = hashedPassword;
     }
     if (updateUserDto.profilePublicity !== undefined) {
-      prismaInput.profilePublicity = PROFILE_PUBLICITY_TYPE_TO_ENUM[updateUserDto.profilePublicity];
+      prismaInput.profilePublicity =
+        PROFILE_PUBLICITY_TYPE_TO_ENUM[updateUserDto.profilePublicity];
     }
     try {
       const userModel = await this.prisma.user.update({
@@ -168,10 +179,11 @@ export class UsersService {
   }
 
   remove(id: number): Promise<UserResponseDto> {
-    return this.prisma.user.delete({
-      where: { id },
-      select: userResponseSelect,
-    })
-    .then(mapUserPrismaModelToDto);
+    return this.prisma.user
+      .delete({
+        where: { id },
+        select: userResponseSelect,
+      })
+      .then(mapUserPrismaModelToDto);
   }
 }

--- a/apps/backend/src/users/users.service.ts
+++ b/apps/backend/src/users/users.service.ts
@@ -16,7 +16,7 @@ import {
 import { UserNotFoundError } from './errors/userNotFound.error';
 import { UserPasswordInputInvalidError } from './errors/userPasswordInputInvalid.error';
 import { UserAlreadyExistsError } from './errors/userAlreadyExists.error';
-import { mapUserPrismaModelOrNullToDto, mapUserPrismaModelToDto } from './users.mapping';
+import { mapUserPrismaModelOrNullToDto, mapUserPrismaModelToDto, PROFILE_PUBLICITY_TYPE_TO_ENUM } from './users.mapping';
 
 export const userResponseSelect: Prisma.UserSelect = {
   id: true,
@@ -108,9 +108,18 @@ export class UsersService {
       throw new UserNotFoundError(id);
     }
 
-    const passwordValid = user
-      ? await bcrypt.compare(updateUserDto.currentPassword, user.password)
-      : false;
+    // Require current password for sensitive updates (username, email, password)
+    const requiresPassword = updateUserDto.username !== undefined ||
+                             updateUserDto.email !== undefined ||
+                             updateUserDto.password !== undefined;
+
+    let passwordValid = true;
+    if (requiresPassword) {
+      if (!updateUserDto.currentPassword) {
+        throw new UserPasswordInputInvalidError('Current password is required for this update');
+      }
+      passwordValid = await bcrypt.compare(updateUserDto.currentPassword, user.password);
+    }
     if (!passwordValid) {
       throw new UserPasswordInputInvalidError('Invalid current password');
     }
@@ -122,11 +131,19 @@ export class UsersService {
         this.envService.get('SALT_ROUNDS'),
       ));
 
-    const prismaInput: Prisma.UserUpdateInput = {
-      username: updateUserDto.username,
-      email: updateUserDto.email,
-      password: hashedPassword,
-    };
+    const prismaInput: Prisma.UserUpdateInput = {};
+    if (updateUserDto.username !== undefined) {
+      prismaInput.username = updateUserDto.username;
+    }
+    if (updateUserDto.email !== undefined) {
+      prismaInput.email = updateUserDto.email;
+    }
+    if (hashedPassword !== undefined) {
+      prismaInput.password = hashedPassword;
+    }
+    if (updateUserDto.profilePublicity !== undefined) {
+      prismaInput.profilePublicity = PROFILE_PUBLICITY_TYPE_TO_ENUM[updateUserDto.profilePublicity];
+    }
     try {
       const userModel = await this.prisma.user.update({
         where: { id },

--- a/apps/client/src/apis/UserApi.ts
+++ b/apps/client/src/apis/UserApi.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import ky, { HTTPError } from 'ky'
 import type {
   CreateUserDto,
@@ -70,9 +70,13 @@ async function patchUpdateUser(
 }
 
 export function useUpdateUserMutation() {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: ({ update }: { update: UpdateUserDto }) => {
       return patchUpdateUser(update)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['user'] });
     },
   })
 }

--- a/apps/client/src/apis/UserApi.ts
+++ b/apps/client/src/apis/UserApi.ts
@@ -70,13 +70,13 @@ async function patchUpdateUser(
 }
 
 export function useUpdateUserMutation() {
-  const queryClient = useQueryClient();
+  const queryClient = useQueryClient()
   return useMutation({
     mutationFn: ({ update }: { update: UpdateUserDto }) => {
       return patchUpdateUser(update)
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['user'] });
+      queryClient.invalidateQueries({ queryKey: ['user'] })
     },
   })
 }

--- a/apps/client/src/features/goals/GoalsPage.tsx
+++ b/apps/client/src/features/goals/GoalsPage.tsx
@@ -12,8 +12,9 @@ import { ErrorBodyComponent } from '@/components/custom/ErrorComponents'
 import { EmptyStateBodyComponent } from '@/components/custom/EmptyStateComponents'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import DropdownMenuOptions from '@/components/custom/DropdownMenuOptions'
-import { useLogoutUserMutation } from '@/apis/UserApi'
+import { useLogoutUserMutation, useUser } from '@/apis/UserApi'
 import { useCurrentYear } from '@/hooks/useCurrentDate'
+import { getInitials } from '@/lib/stringUtils'
 
 // TODOs #17: investigate if lazy loading will help with initial render speed of goals page
 export const GoalsPage = () => {
@@ -27,6 +28,10 @@ export const GoalsPage = () => {
     .sort((a, b) => a.order - b.order)
   // TODOs #16: handle filtering on backend? how to fit with infinite scroll vs. pagination?
 
+  const { data: userData, isLoading: userLoading, error: userError } = useUser()
+  const username = userData?.username || 'Unknown'
+  const usernameInitials = getInitials(username);
+
   const { mutate: logoutUserMutateFn } = useLogoutUserMutation()
 
   const profileMenuItems: Array<DropdownMenuOptionsItemConfig> = [
@@ -36,7 +41,7 @@ export const GoalsPage = () => {
       onClick: () =>
         navigate({
           to: '/profile/$profileName',
-          params: { profileName: 'me' },
+          params: { profileName: username },
         }),
     },
     { label: 'Settings', onClick: () => navigate({ to: '/settings' }) },
@@ -91,7 +96,7 @@ export const GoalsPage = () => {
               itemsConfig={profileMenuItems}
             >
               <Avatar>
-                <AvatarFallback>CN</AvatarFallback>
+                <AvatarFallback>{usernameInitials}</AvatarFallback>
               </Avatar>
             </DropdownMenuOptions>
           </>

--- a/apps/client/src/features/goals/GoalsPage.tsx
+++ b/apps/client/src/features/goals/GoalsPage.tsx
@@ -28,9 +28,11 @@ export const GoalsPage = () => {
     .sort((a, b) => a.order - b.order)
   // TODOs #16: handle filtering on backend? how to fit with infinite scroll vs. pagination?
 
+  // Un-used variables to be addressed in #12
+  /* eslint-disable @typescript-eslint/no-unused-vars */
   const { data: userData, isLoading: userLoading, error: userError } = useUser()
   const username = userData?.username || 'Unknown'
-  const usernameInitials = getInitials(username);
+  const usernameInitials = getInitials(username)
 
   const { mutate: logoutUserMutateFn } = useLogoutUserMutation()
 

--- a/apps/client/src/features/profile/ProfilePage.tsx
+++ b/apps/client/src/features/profile/ProfilePage.tsx
@@ -22,7 +22,7 @@ export const ProfilePage = () => {
   const [selectedYear, setSelectedYear] = useState<number>(currentYear)
 
   const { profileName } = route.useParams()
-  const profileNameInitials = getInitials(profileName);
+  const profileNameInitials = getInitials(profileName)
 
   // Un-used variables to be addressed in #12
   /* eslint-disable @typescript-eslint/no-unused-vars */
@@ -74,7 +74,9 @@ export const ProfilePage = () => {
       {profileData && (
         <div className="bg-white rounded-xl p-2.5 flex flex-row gap-3">
           <Avatar className="size-20">
-            <AvatarFallback className="text-2xl">{profileNameInitials}</AvatarFallback>
+            <AvatarFallback className="text-2xl">
+              {profileNameInitials}
+            </AvatarFallback>
           </Avatar>
           <div className="flex flex-col gap-1.5">
             <h2>{profileData.username}</h2>

--- a/apps/client/src/features/profile/ProfilePage.tsx
+++ b/apps/client/src/features/profile/ProfilePage.tsx
@@ -12,6 +12,7 @@ import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 
 import { TopBarConfig } from '@/components/custom/TopBar'
 import { useCurrentYear } from '@/hooks/useCurrentDate'
+import { getInitials } from '@/lib/stringUtils'
 
 export const ProfilePage = () => {
   const navigate = useNavigate()
@@ -21,6 +22,7 @@ export const ProfilePage = () => {
   const [selectedYear, setSelectedYear] = useState<number>(currentYear)
 
   const { profileName } = route.useParams()
+  const profileNameInitials = getInitials(profileName);
 
   // Un-used variables to be addressed in #12
   /* eslint-disable @typescript-eslint/no-unused-vars */
@@ -72,7 +74,7 @@ export const ProfilePage = () => {
       {profileData && (
         <div className="bg-white rounded-xl p-2.5 flex flex-row gap-3">
           <Avatar className="size-20">
-            <AvatarFallback className="text-2xl">CN</AvatarFallback>
+            <AvatarFallback className="text-2xl">{profileNameInitials}</AvatarFallback>
           </Avatar>
           <div className="flex flex-col gap-1.5">
             <h2>{profileData.username}</h2>

--- a/apps/client/src/features/settings/SettingsPage.tsx
+++ b/apps/client/src/features/settings/SettingsPage.tsx
@@ -1,12 +1,12 @@
 import { useNavigate } from '@tanstack/react-router'
 import { ChevronRight } from 'lucide-react'
+import { ProfilePublicityType } from '@habit-tracker/validation-schemas'
 import { Label } from '@/components/ui/label'
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import { TopBarClose } from '@/components/custom/TopBar'
 import { Switch } from '@/components/ui/switch'
 import { Separator } from '@/components/ui/separator'
-import { useUser, useUpdateUserMutation } from '@/apis/UserApi'
-import { ProfilePublicityType } from '@habit-tracker/validation-schemas'
+import { useUpdateUserMutation, useUser } from '@/apis/UserApi'
 
 enum SettingGroupStyle {
   Default = 'default',
@@ -70,10 +70,13 @@ type SettingItem =
 
 export function SettingsPage() {
   const navigate = useNavigate()
+
+  // Un-used variables to be addressed in #12
+  /* eslint-disable @typescript-eslint/no-unused-vars */
   const { data: userData, isLoading: userLoading, error: userError } = useUser()
   const updateUserMutation = useUpdateUserMutation()
 
-  const userPublicity = userData?.profilePublicity;
+  const userPublicity = userData?.profilePublicity
 
   const SETTING_GROUPS: Array<SettingGroup> = [
     // Appearance

--- a/apps/client/src/features/settings/SettingsPage.tsx
+++ b/apps/client/src/features/settings/SettingsPage.tsx
@@ -5,7 +5,8 @@ import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import { TopBarClose } from '@/components/custom/TopBar'
 import { Switch } from '@/components/ui/switch'
 import { Separator } from '@/components/ui/separator'
-import { useUser } from '@/apis/UserApi'
+import { useUser, useUpdateUserMutation } from '@/apis/UserApi'
+import { ProfilePublicityType } from '@habit-tracker/validation-schemas'
 
 enum SettingGroupStyle {
   Default = 'default',
@@ -70,6 +71,7 @@ type SettingItem =
 export function SettingsPage() {
   const navigate = useNavigate()
   const { data: userData, isLoading: userLoading, error: userError } = useUser()
+  const updateUserMutation = useUpdateUserMutation()
 
   const userPublicity = userData?.profilePublicity;
 
@@ -141,18 +143,21 @@ export function SettingsPage() {
               {
                 label: 'Public',
                 detail: 'Anyone can see your profile info',
-                value: 'public',
+                value: ProfilePublicityType.Public,
               },
               {
                 label: 'Private',
                 detail: 'Only you can see your profile',
-                value: 'private',
+                value: ProfilePublicityType.Private,
               },
             ],
-            currentValue: userPublicity || 'private', // Default to private if not loaded
+            currentValue: userPublicity || ProfilePublicityType.Private, // Default to private if not loaded
             onValueChange: (val: string) => {
-              console.log('value changed', val)
-              // TODOs #42 actually mutate user profile publicity...
+              updateUserMutation.mutate({
+                update: {
+                  profilePublicity: val,
+                },
+              })
             },
           },
         },

--- a/apps/client/src/features/settings/SettingsPage.tsx
+++ b/apps/client/src/features/settings/SettingsPage.tsx
@@ -155,7 +155,7 @@ export function SettingsPage() {
             onValueChange: (val: string) => {
               updateUserMutation.mutate({
                 update: {
-                  profilePublicity: val,
+                  profilePublicity: val as ProfilePublicityType,
                 },
               })
             },

--- a/apps/client/src/features/settings/SettingsPage.tsx
+++ b/apps/client/src/features/settings/SettingsPage.tsx
@@ -5,6 +5,7 @@ import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import { TopBarClose } from '@/components/custom/TopBar'
 import { Switch } from '@/components/ui/switch'
 import { Separator } from '@/components/ui/separator'
+import { useUser } from '@/apis/UserApi'
 
 enum SettingGroupStyle {
   Default = 'default',
@@ -37,12 +38,14 @@ interface ToggleConfig {
 interface RadioGroupCompactConfig {
   label: string
   values: Array<{ label: string; value: string }>
+  currentValue: string
   onValueChange: (val: string) => void
 }
 
 interface RadioGroupDetailedConfig {
   label: string
   values: Array<{ label: string; detail: string; value: string }>
+  currentValue: string
   onValueChange: (val: string) => void
 }
 
@@ -66,6 +69,9 @@ type SettingItem =
 
 export function SettingsPage() {
   const navigate = useNavigate()
+  const { data: userData, isLoading: userLoading, error: userError } = useUser()
+
+  const userPublicity = userData?.profilePublicity;
 
   const SETTING_GROUPS: Array<SettingGroup> = [
     // Appearance
@@ -80,8 +86,10 @@ export function SettingsPage() {
               { label: 'Light', value: 'light' },
               { label: 'Dark', value: 'dark' },
             ],
+            currentValue: 'light', // TODO: Get from theme context or state
             onValueChange: (val: string) => {
               console.log('value changed', val)
+              // TODOs #xx?? add control for changing theme
             },
           },
         },
@@ -115,6 +123,7 @@ export function SettingsPage() {
             label: 'Show Descriptions',
             onToggleChange: () => {
               console.log('value changed')
+              // TODOs #xx?? add control for showing/ hiding descriptions
             },
           },
         },
@@ -140,8 +149,10 @@ export function SettingsPage() {
                 value: 'private',
               },
             ],
+            currentValue: userPublicity || 'private', // Default to private if not loaded
             onValueChange: (val: string) => {
               console.log('value changed', val)
+              // TODOs #42 actually mutate user profile publicity...
             },
           },
         },
@@ -239,6 +250,8 @@ export function SettingsPage() {
                         <>
                           <RadioGroup
                             className={`flex flex-col gap-2 ${settingItemPaddingClass}`}
+                            value={item.config.currentValue}
+                            onValueChange={item.config.onValueChange}
                           >
                             <h2 className="text-sm font-semibold">
                               {item.config.label}
@@ -269,6 +282,8 @@ export function SettingsPage() {
                         <>
                           <RadioGroup
                             className={`flex flex-col gap-2 ${settingItemPaddingClass}`}
+                            value={item.config.currentValue}
+                            onValueChange={item.config.onValueChange}
                           >
                             <h2 className="text-sm font-semibold">
                               {item.config.label}

--- a/apps/client/src/lib/stringUtils.ts
+++ b/apps/client/src/lib/stringUtils.ts
@@ -2,6 +2,14 @@
  * Common string manipulation utilities
  */
 
-export const capitalizeFirstLetter = (str: string) => {
+export function capitalizeFirstLetter(str: string): string {
   return str.charAt(0).toUpperCase() + str.slice(1)
+}
+
+export function getInitials(username: string): string {
+  return username
+    .split(' ')
+    .map(word => word.charAt(0).toUpperCase())
+    .join('')
+    .slice(0, 2); // Limit to 2 initials if needed
 }

--- a/apps/client/src/lib/stringUtils.ts
+++ b/apps/client/src/lib/stringUtils.ts
@@ -9,7 +9,7 @@ export function capitalizeFirstLetter(str: string): string {
 export function getInitials(username: string): string {
   return username
     .split(' ')
-    .map(word => word.charAt(0).toUpperCase())
+    .map((word) => word.charAt(0).toUpperCase())
     .join('')
-    .slice(0, 2); // Limit to 2 initials if needed
+    .slice(0, 2) // Limit to 2 initials if needed
 }

--- a/packages/validation-schemas/src/schemas/user.schemas.base.ts
+++ b/packages/validation-schemas/src/schemas/user.schemas.base.ts
@@ -31,10 +31,18 @@ export type LoginUserDto = z.infer<typeof LoginUserSchema>;
 /**
  * Output Schemas
  */
+export enum ProfilePublicityType {
+  Public = "PUBLIC",
+  Private = "PRIVATE",
+}
+
+const ProfilePublicityTypeSchema = z.nativeEnum(ProfilePublicityType);
+
 export const UserResponseSchema = z.object({
   id: z.number(),
   username: z.string(),
   email: z.string().email(),
+  profilePublicity: ProfilePublicityTypeSchema
 });
 
 /**

--- a/packages/validation-schemas/src/schemas/user.schemas.base.ts
+++ b/packages/validation-schemas/src/schemas/user.schemas.base.ts
@@ -1,6 +1,17 @@
 import { z } from "zod";
 
 /**
+ * Enums
+ */
+export enum ProfilePublicityType {
+  Public = "PUBLIC",
+  Private = "PRIVATE",
+}
+
+const ProfilePublicityTypeSchema = z.nativeEnum(ProfilePublicityType);
+
+
+/**
  * Input Schemas
  */
 const UserSchema = z.object({
@@ -12,7 +23,8 @@ const UserSchema = z.object({
 export const CreateUserSchema = UserSchema;
 export const UpdateUserSchema = CreateUserSchema.partial().and(
   z.object({
-    currentPassword: z.string(),
+    currentPassword: z.string().optional(),
+    profilePublicity: ProfilePublicityTypeSchema.optional(),
   }),
 );
 
@@ -31,13 +43,6 @@ export type LoginUserDto = z.infer<typeof LoginUserSchema>;
 /**
  * Output Schemas
  */
-export enum ProfilePublicityType {
-  Public = "PUBLIC",
-  Private = "PRIVATE",
-}
-
-const ProfilePublicityTypeSchema = z.nativeEnum(ProfilePublicityType);
-
 export const UserResponseSchema = z.object({
   id: z.number(),
   username: z.string(),

--- a/packages/validation-schemas/src/schemas/user.schemas.base.ts
+++ b/packages/validation-schemas/src/schemas/user.schemas.base.ts
@@ -10,7 +10,6 @@ export enum ProfilePublicityType {
 
 const ProfilePublicityTypeSchema = z.nativeEnum(ProfilePublicityType);
 
-
 /**
  * Input Schemas
  */
@@ -47,7 +46,7 @@ export const UserResponseSchema = z.object({
   id: z.number(),
   username: z.string(),
   email: z.string().email(),
-  profilePublicity: ProfilePublicityTypeSchema
+  profilePublicity: ProfilePublicityTypeSchema,
 });
 
 /**


### PR DESCRIPTION
Backend:
* Updated `UserResponseDto` to include profile publicity, added mapping of user prisma model to DTO
* Updated `users.service` password-required controls (profile publicity change doesn't require password)
* Fixed wrong type for `validateUser` + login requests (`JwtRequestUser` as only need essential user fields)

Frontend:
* Updated `UserApi` to invalidate user query when user mutation successful
* Update `SettingsPage` so radio for publicity hooked up
* Fixed `AvatarFallback`, now shows 1st initial
