### PR TITLE
Feature/#12 loading error

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -47,10 +47,12 @@
     "date-fns": "^4.1.0",
     "ky": "^1.8.1",
     "lucide-react": "^0.476.0",
+    "next-themes": "^0.4.6",
     "react": "^19.0.0",
     "react-day-picker": "^9.8.0",
     "react-dom": "^19.0.0",
     "recharts": "^3.0.2",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.0.2",
     "tailwindcss": "^4.0.6",
     "tailwindcss-animate": "^1.0.7"

--- a/apps/client/src/apis/GoalApi.ts
+++ b/apps/client/src/apis/GoalApi.ts
@@ -262,11 +262,14 @@ async function fetchGoalStatisticsBySearchParams(
   return api.get(`entries/statistics?${searchSegment}`).json()
 }
 
-export function useGoalStatistics(searchParams: SearchParamsGoalEntryDto) {
+export function useGoalStatistics(
+  searchParams: SearchParamsGoalEntryDto,
+  enabled: boolean
+) {
   return useQuery<GoalStatisticsReponse, HTTPError>({
     queryKey: ['goalStatistics', searchParams],
     queryFn: () => fetchGoalStatisticsBySearchParams(searchParams),
-    enabled: !!searchParams.goalId,
+    enabled: enabled,
     retry: REACT_QUERY_RETRY_NUM,
   })
 }

--- a/apps/client/src/apis/GoalApi.ts
+++ b/apps/client/src/apis/GoalApi.ts
@@ -60,6 +60,7 @@ async function postCreateGoal(newGoal: CreateGoalDto): Promise<GoalResponse> {
 
 export function useCreateGoalMutation() {
   return useMutation({
+    mutationKey: ['createGoal'],
     mutationFn: (newGoal: CreateGoalDto) => {
       return postCreateGoal(newGoal)
     },
@@ -75,6 +76,7 @@ async function patchUpdateGoal(
 
 export function useUpdateGoalMutation() {
   return useMutation({
+    mutationKey: ['updateGoal'],
     mutationFn: ({ id, update }: { id: number; update: UpdateGoalDto }) => {
       return patchUpdateGoal(id, update)
     },
@@ -141,6 +143,7 @@ async function deleteGoal(goalId: number): Promise<GoalResponse> {
 
 export function useDeleteGoalMutation() {
   return useMutation({
+    mutationKey: ['deleteGoal'],
     mutationFn: (goalId: number) => {
       return deleteGoal(goalId)
     },
@@ -153,6 +156,7 @@ async function reorderGoals(reorderGoal: ReorderGoalDto): Promise<void> {
 
 export function useReorderGoalsMutation() {
   return useMutation({
+    mutationKey: ['reorderGoals'],
     mutationFn: (reorder: ReorderGoalDto) => {
       return reorderGoals(reorder)
     },
@@ -322,6 +326,7 @@ async function postCreateGoalEntry(
 
 export function useCreateGoalEntryMutation() {
   return useMutation({
+    mutationKey: ['createGoalEntry'],
     mutationFn: ({
       goalId,
       createDto,
@@ -346,6 +351,7 @@ async function patchUpdateGoalEntry(
 
 export function useUpdateGoalEntryMutation() {
   return useMutation({
+    mutationKey: ['updateGoalEntry'],
     mutationFn: ({
       goalId,
       entryId,
@@ -369,6 +375,7 @@ async function deleteGoalEntry(
 
 export function useDeleteGoalEntryMutation() {
   return useMutation({
+    mutationKey: ['deleteGoalEntry'],
     mutationFn: ({ goalId, entryId }: { goalId: number; entryId: number }) => {
       return deleteGoalEntry(goalId, entryId)
     },

--- a/apps/client/src/apis/GoalApi.ts
+++ b/apps/client/src/apis/GoalApi.ts
@@ -264,7 +264,7 @@ async function fetchGoalStatisticsBySearchParams(
 
 export function useGoalStatistics(
   searchParams: SearchParamsGoalEntryDto,
-  enabled: boolean
+  enabled: boolean,
 ) {
   return useQuery<GoalStatisticsReponse, HTTPError>({
     queryKey: ['goalStatistics', searchParams],

--- a/apps/client/src/apis/UserApi.ts
+++ b/apps/client/src/apis/UserApi.ts
@@ -1,11 +1,12 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import ky, { HTTPError, isHTTPError } from 'ky'
+import ky, { HTTPError } from 'ky'
 import type {
   CreateUserDto,
   LoginUserDto,
   UpdateUserDto,
   UserResponseDto,
 } from '@habit-tracker/validation-schemas'
+import { queryClient } from '@/integrations/tanstack-query/root-provider'
 
 const KY_FETCH_RETRY_NUM = 0
 const REACT_QUERY_RETRY_NUM = 0
@@ -16,6 +17,29 @@ const api = ky.create({
   credentials: 'include',
   retry: KY_FETCH_RETRY_NUM,
 })
+
+
+/**
+ * Helper functions
+ */
+
+export async function checkAuthUser() {
+  const user = await queryClient.ensureQueryData({
+    queryKey: ['user'],
+    queryFn: fetchUser,
+  })
+  return user
+}
+
+export function clearAuthUser() {
+  // Remove user query (used for determining if logged in)
+  queryClient.removeQueries({
+    queryKey: ['user']
+  });
+  // Also clear whole cache (ensure e.g. 'goals' data is cleared as only relevant to logged in user)
+  queryClient.clear()
+}
+
 
 /**
  * /users
@@ -118,6 +142,8 @@ export function useLogoutUserMutation() {
   return useMutation({
     mutationKey: ['logoutUser'],
     mutationFn: () => {
+      // Clear user data when log out is requested
+      clearAuthUser()
       return postLogoutUser()
     },
   })

--- a/apps/client/src/apis/UserApi.ts
+++ b/apps/client/src/apis/UserApi.ts
@@ -58,6 +58,7 @@ async function postCreateUser(
 
 export function useCreateUserMutation() {
   return useMutation({
+    mutationKey: ['createUser'],
     mutationFn: (newUser: CreateUserDto) => {
       return postCreateUser(newUser)
     },
@@ -73,6 +74,7 @@ async function patchUpdateUser(
 export function useUpdateUserMutation() {
   const queryClient = useQueryClient()
   return useMutation({
+    mutationKey: ['updateUser'],
     mutationFn: ({ update }: { update: UpdateUserDto }) => {
       return patchUpdateUser(update)
     },
@@ -88,6 +90,7 @@ async function deleteUser(): Promise<UserResponseDto> {
 
 export function useDeleteUserMutation() {
   return useMutation({
+    mutationKey: ['deleteUser'],
     mutationFn: () => {
       return deleteUser()
     },
@@ -100,6 +103,7 @@ async function postLoginUser(user: LoginUserDto): Promise<UserResponseDto> {
 
 export function useLoginUserMutation() {
   return useMutation({
+    mutationKey: ['loginUser'],
     mutationFn: (user: LoginUserDto) => {
       return postLoginUser(user)
     },
@@ -112,6 +116,7 @@ async function postLogoutUser() {
 
 export function useLogoutUserMutation() {
   return useMutation({
+    mutationKey: ['logoutUser'],
     mutationFn: () => {
       return postLogoutUser()
     },

--- a/apps/client/src/apis/UserApi.ts
+++ b/apps/client/src/apis/UserApi.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import ky, { HTTPError } from 'ky'
+import ky, { HTTPError, isHTTPError } from 'ky'
 import type {
   CreateUserDto,
   LoginUserDto,
@@ -23,19 +23,20 @@ const api = ky.create({
 
 export async function fetchUser(): Promise<UserResponseDto | null> {
   try {
-    return await api.get('users/me').json()
+    const data = await api.get('users/me').json<UserResponseDto | null>();
+    return data;
   } catch (err: unknown) {
     if (err instanceof HTTPError) {
-      const errorJson = await err.response.json()
-      console.error('HTTP Error:', err.response.status, errorJson)
+      console.error('HTTP Error:', err.response.status)
       if (err.response.status === 401) {
         return null
       }
-    } else if (err instanceof Error) {
-      console.error('General Error:', err.message)
+    } else if (err instanceof TypeError) {
+      console.error('Network error:', err.message)
     } else {
-      console.error('An unknown error occurred', err)
+      console.error('Unexpected error:', err)
     }
+
     // TODOs #12 fix error handling if other error occurs e.g. backend down hence no HTTPError
     throw err
   }

--- a/apps/client/src/apis/UserApi.ts
+++ b/apps/client/src/apis/UserApi.ts
@@ -26,7 +26,20 @@ const api = ky.create({
 export async function checkAuthUser() {
   const user = await queryClient.ensureQueryData({
     queryKey: ['user'],
-    queryFn: fetchUser,
+    queryFn: async () => {
+      try {
+        const user = await fetchUser();
+        return user;
+      }
+      catch (err: unknown) {
+        if (err instanceof HTTPError) {
+          if (err.response.status === 401) {
+            return null
+          }
+        }
+        throw err
+      }
+    },
   })
   return user
 }
@@ -46,24 +59,7 @@ export function clearAuthUser() {
  */
 
 export async function fetchUser(): Promise<UserResponseDto | null> {
-  try {
-    const data = await api.get('users/me').json<UserResponseDto | null>();
-    return data;
-  } catch (err: unknown) {
-    if (err instanceof HTTPError) {
-      console.error('HTTP Error:', err.response.status)
-      if (err.response.status === 401) {
-        return null
-      }
-    } else if (err instanceof TypeError) {
-      console.error('Network error:', err.message)
-    } else {
-      console.error('Unexpected error:', err)
-    }
-
-    // TODOs #12 fix error handling if other error occurs e.g. backend down hence no HTTPError
-    throw err
-  }
+  return await api.get('users/me').json<UserResponseDto | null>();
 }
 
 export function useUser() {

--- a/apps/client/src/apis/UserApi.ts
+++ b/apps/client/src/apis/UserApi.ts
@@ -18,7 +18,6 @@ const api = ky.create({
   retry: KY_FETCH_RETRY_NUM,
 })
 
-
 /**
  * Helper functions
  */
@@ -28,10 +27,9 @@ export async function checkAuthUser() {
     queryKey: ['user'],
     queryFn: async () => {
       try {
-        const fetchedUser = await fetchUser();
-        return fetchedUser;
-      }
-      catch (err: unknown) {
+        const fetchedUser = await fetchUser()
+        return fetchedUser
+      } catch (err: unknown) {
         if (err instanceof HTTPError) {
           if (err.response.status === 401) {
             return null
@@ -47,19 +45,18 @@ export async function checkAuthUser() {
 export function clearAuthUser() {
   // Remove user query (used for determining if logged in)
   queryClient.removeQueries({
-    queryKey: ['user']
-  });
+    queryKey: ['user'],
+  })
   // Also clear whole cache (ensure e.g. 'goals' data is cleared as only relevant to logged in user)
   queryClient.clear()
 }
-
 
 /**
  * /users
  */
 
 export async function fetchUser(): Promise<UserResponseDto | null> {
-  return await api.get('users/me').json<UserResponseDto | null>();
+  return await api.get('users/me').json<UserResponseDto | null>()
 }
 
 export function useUser() {

--- a/apps/client/src/apis/UserApi.ts
+++ b/apps/client/src/apis/UserApi.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQuery } from '@tanstack/react-query'
 import ky, { HTTPError } from 'ky'
 import type {
   CreateUserDto,
@@ -28,8 +28,8 @@ export async function checkAuthUser() {
     queryKey: ['user'],
     queryFn: async () => {
       try {
-        const user = await fetchUser();
-        return user;
+        const fetchedUser = await fetchUser();
+        return fetchedUser;
       }
       catch (err: unknown) {
         if (err instanceof HTTPError) {
@@ -92,7 +92,6 @@ async function patchUpdateUser(
 }
 
 export function useUpdateUserMutation() {
-  const queryClient = useQueryClient()
   return useMutation({
     mutationKey: ['updateUser'],
     mutationFn: ({ update }: { update: UpdateUserDto }) => {

--- a/apps/client/src/components/custom/DialogComponents.tsx
+++ b/apps/client/src/components/custom/DialogComponents.tsx
@@ -9,6 +9,8 @@ import {
   Dialog as ShadcnDialog,
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
+import { Spinner } from '../ui/spinner'
+import { useState } from 'react'
 
 enum DialogTriggerSubtype {
   Slot = 'slot',
@@ -82,27 +84,34 @@ function Dialog({
   )
 }
 
-interface DeleteDialogComponentProps {
+interface DeleteDialogProps {
   title: string
   description: string
-  onDelete: () => void
+  onDelete: () => Promise<void>
   children: React.ReactNode
 }
 
-function DeleteDialog({
-  title,
-  description,
-  onDelete,
-  children,
-}: DeleteDialogComponentProps) {
+function DeleteDialog({ title, description, onDelete, children }: DeleteDialogProps) {
+  const [isDeleting, setIsDeleting] = useState(false)
+
+  const handleClick = async () => {
+    setIsDeleting(true)
+    try {
+      await onDelete()
+    } finally {
+      setIsDeleting(false)
+    }
+  }
+
   const buttonsSlot = (
     <div className="flex flex-row gap-1.5">
       <DialogClose asChild>
-        <Button type="button" variant="secondary">
+        <Button type="button" variant="secondary" disabled={isDeleting}>
           Cancel
         </Button>
       </DialogClose>
-      <Button type="button" variant="destructive" onClick={onDelete}>
+      <Button type="button" variant="destructive" onClick={handleClick} disabled={isDeleting}>
+        {isDeleting && <Spinner data-icon="inline-start" />}
         Delete
       </Button>
     </div>

--- a/apps/client/src/components/custom/DialogComponents.tsx
+++ b/apps/client/src/components/custom/DialogComponents.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react'
+import { Spinner } from '../ui/spinner'
 import {
   DialogClose,
   DialogContent,
@@ -9,8 +11,6 @@ import {
   Dialog as ShadcnDialog,
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
-import { Spinner } from '../ui/spinner'
-import { useState } from 'react'
 
 enum DialogTriggerSubtype {
   Slot = 'slot',

--- a/apps/client/src/components/custom/DialogComponents.tsx
+++ b/apps/client/src/components/custom/DialogComponents.tsx
@@ -91,7 +91,12 @@ interface DeleteDialogProps {
   children: React.ReactNode
 }
 
-function DeleteDialog({ title, description, onDelete, children }: DeleteDialogProps) {
+function DeleteDialog({
+  title,
+  description,
+  onDelete,
+  children,
+}: DeleteDialogProps) {
   const [isDeleting, setIsDeleting] = useState(false)
 
   const handleClick = async () => {
@@ -110,7 +115,12 @@ function DeleteDialog({ title, description, onDelete, children }: DeleteDialogPr
           Cancel
         </Button>
       </DialogClose>
-      <Button type="button" variant="destructive" onClick={handleClick} disabled={isDeleting}>
+      <Button
+        type="button"
+        variant="destructive"
+        onClick={handleClick}
+        disabled={isDeleting}
+      >
         {isDeleting && <Spinner data-icon="inline-start" />}
         Delete
       </Button>

--- a/apps/client/src/components/custom/ErrorComponents.tsx
+++ b/apps/client/src/components/custom/ErrorComponents.tsx
@@ -138,7 +138,7 @@ function triggerErrorToast(error: unknown) {
   const errorMessage = getErrorMessage(error);
   toast.error(errorMessage, {
     position: 'top-center',
-    duration: 7000,
+    duration: 5000,
   })
 }
 

--- a/apps/client/src/components/custom/ErrorComponents.tsx
+++ b/apps/client/src/components/custom/ErrorComponents.tsx
@@ -4,20 +4,35 @@ import { HTTPError } from 'ky'
 import { Dialog, DialogTriggerSubtype } from './DialogComponents'
 import { Button } from '@/components/ui/button'
 import { toast } from 'sonner'
+import clsx from 'clsx'
 
 interface ErrorBaseProps {
   error: Error | HTTPError
 }
 
+export enum ErrorBodyComponentSize {
+  Small = "small",
+  Large = "large",
+}
+
+export enum ErrorBodyComponentPosition {
+  TopMargin = "top-margin",
+  Centered = "centered"
+}
+
 interface ErrorBodyComponentProps extends ErrorBaseProps {
   onRefreshClick: () => void
   onBackClick?: () => void
+  size?: ErrorBodyComponentSize
+  position?: ErrorBodyComponentPosition
 }
 
 function ErrorBodyComponent({
   error,
   onRefreshClick,
   onBackClick,
+  size=ErrorBodyComponentSize.Large,
+  position=ErrorBodyComponentPosition.TopMargin
 }: ErrorBodyComponentProps) {
   const errorText = (() => {
     if (error instanceof HTTPError) {
@@ -28,8 +43,14 @@ function ErrorBodyComponent({
   })()
 
   return (
-    <div className="flex flex-col gap-4 pt-18 items-center">
-      <CircleAlert size={`64px`} strokeWidth={2.5} />
+    <div className={
+      clsx(
+        "flex flex-col items-center",
+        size === ErrorBodyComponentSize.Large ? "gap-4" : "gap-2",
+        position === ErrorBodyComponentPosition.TopMargin ? "pt-18" : "justify-center h-full",
+      )
+      }>
+      <CircleAlert size={size === ErrorBodyComponentSize.Large ? '64px' : '32px'} strokeWidth={size === ErrorBodyComponentSize.Large ? 2.5 : 2} />
       <div>
         <h2 className="text-base font-black text-center">
           Oops! Something went wrong

--- a/apps/client/src/components/custom/ErrorComponents.tsx
+++ b/apps/client/src/components/custom/ErrorComponents.tsx
@@ -3,6 +3,7 @@ import { CircleAlert } from 'lucide-react'
 import { HTTPError } from 'ky'
 import { Dialog, DialogTriggerSubtype } from './DialogComponents'
 import { Button } from '@/components/ui/button'
+import { toast } from 'sonner'
 
 interface ErrorBaseProps {
   error: Error | HTTPError
@@ -107,4 +108,38 @@ function ErrorDialogComponent({
   )
 }
 
-export { ErrorBodyComponent, ErrorDialogComponent }
+function triggerErrorToast(error: unknown) {
+  const getErrorMessage = (error: unknown): string => {
+    if (error instanceof HTTPError) {
+      const httpErrorLabel = (() => {
+        switch (error.response.status) {
+          case 400:
+            return 'Invalid input. Please check and try again.'
+          case 401:
+            return 'You are not logged in. Please log in again.'
+          case 403:
+            return 'You do not have permission to perform this action.'
+          case 500:
+            return 'Server error. Please try again later.'
+          default:
+            return 'Something went wrong. Please try again.'
+        }
+      })();
+      const httpErrorMessage = `${httpErrorLabel} (${error.response.status})`
+      return httpErrorMessage;
+    } else if (error instanceof TypeError) {
+      // e.g. Network failed
+      return 'Network error. Please check your connection.'
+    } else {
+      return 'An unexpected error occurred.'
+    };
+  };
+
+  const errorMessage = getErrorMessage(error);
+  toast.error(errorMessage, {
+    position: 'top-center',
+    duration: 7000,
+  })
+}
+
+export { ErrorBodyComponent, ErrorDialogComponent, triggerErrorToast }

--- a/apps/client/src/components/custom/ErrorComponents.tsx
+++ b/apps/client/src/components/custom/ErrorComponents.tsx
@@ -1,10 +1,10 @@
 import { CircleAlert } from 'lucide-react'
 
 import { HTTPError } from 'ky'
-import { Dialog, DialogTriggerSubtype } from './DialogComponents'
-import { Button } from '@/components/ui/button'
 import { toast } from 'sonner'
 import clsx from 'clsx'
+import { Dialog, DialogTriggerSubtype } from './DialogComponents'
+import { Button } from '@/components/ui/button'
 
 interface ErrorBaseProps {
   error: Error | HTTPError
@@ -130,10 +130,10 @@ function ErrorDialogComponent({
 }
 
 function triggerErrorToast(error: unknown) {
-  const getErrorMessage = (error: unknown): string => {
-    if (error instanceof HTTPError) {
+  const getErrorMessage = (err: unknown): string => {
+    if (err instanceof HTTPError) {
       const httpErrorLabel = (() => {
-        switch (error.response.status) {
+        switch (err.response.status) {
           case 400:
             return 'Invalid input. Please check and try again.'
           case 401:
@@ -146,9 +146,9 @@ function triggerErrorToast(error: unknown) {
             return 'Something went wrong. Please try again.'
         }
       })();
-      const httpErrorMessage = `${httpErrorLabel} (${error.response.status})`
-      return httpErrorMessage;
-    } else if (error instanceof TypeError) {
+      const msg = `${httpErrorLabel} (${err.response.status})`
+      return msg;
+    } else if (err instanceof TypeError) {
       // e.g. Network failed
       return 'Network error. Please check your connection.'
     } else {

--- a/apps/client/src/components/custom/ErrorComponents.tsx
+++ b/apps/client/src/components/custom/ErrorComponents.tsx
@@ -11,13 +11,13 @@ interface ErrorBaseProps {
 }
 
 export enum ErrorBodyComponentSize {
-  Small = "small",
-  Large = "large",
+  Small = 'small',
+  Large = 'large',
 }
 
 export enum ErrorBodyComponentPosition {
-  TopMargin = "top-margin",
-  Centered = "centered"
+  TopMargin = 'top-margin',
+  Centered = 'centered',
 }
 
 interface ErrorBodyComponentProps extends ErrorBaseProps {
@@ -31,8 +31,8 @@ function ErrorBodyComponent({
   error,
   onRefreshClick,
   onBackClick,
-  size=ErrorBodyComponentSize.Large,
-  position=ErrorBodyComponentPosition.TopMargin
+  size = ErrorBodyComponentSize.Large,
+  position = ErrorBodyComponentPosition.TopMargin,
 }: ErrorBodyComponentProps) {
   const errorText = (() => {
     if (error instanceof HTTPError) {
@@ -43,14 +43,19 @@ function ErrorBodyComponent({
   })()
 
   return (
-    <div className={
-      clsx(
-        "flex flex-col items-center",
-        size === ErrorBodyComponentSize.Large ? "gap-4" : "gap-2",
-        position === ErrorBodyComponentPosition.TopMargin ? "pt-18" : "justify-center h-full",
-      )
-      }>
-      <CircleAlert size={size === ErrorBodyComponentSize.Large ? '64px' : '32px'} strokeWidth={size === ErrorBodyComponentSize.Large ? 2.5 : 2} />
+    <div
+      className={clsx(
+        'flex flex-col items-center',
+        size === ErrorBodyComponentSize.Large ? 'gap-4' : 'gap-2',
+        position === ErrorBodyComponentPosition.TopMargin
+          ? 'pt-18'
+          : 'justify-center h-full',
+      )}
+    >
+      <CircleAlert
+        size={size === ErrorBodyComponentSize.Large ? '64px' : '32px'}
+        strokeWidth={size === ErrorBodyComponentSize.Large ? 2.5 : 2}
+      />
       <div>
         <h2 className="text-base font-black text-center">
           Oops! Something went wrong
@@ -145,18 +150,18 @@ function triggerErrorToast(error: unknown) {
           default:
             return 'Something went wrong. Please try again.'
         }
-      })();
+      })()
       const msg = `${httpErrorLabel} (${err.response.status})`
-      return msg;
+      return msg
     } else if (err instanceof TypeError) {
       // e.g. Network failed
       return 'Network error. Please check your connection.'
     } else {
       return 'An unexpected error occurred.'
-    };
-  };
+    }
+  }
 
-  const errorMessage = getErrorMessage(error);
+  const errorMessage = getErrorMessage(error)
   toast.error(errorMessage, {
     position: 'top-center',
     duration: 5000,

--- a/apps/client/src/components/custom/NotFoundComponent.tsx
+++ b/apps/client/src/components/custom/NotFoundComponent.tsx
@@ -1,0 +1,41 @@
+import { FileQuestion } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { useRouter } from '@tanstack/react-router'
+import { useUser } from '@/apis/UserApi'
+
+interface NotFoundComponentProps {
+  headerText?: string
+  descriptionText?: string
+}
+
+function NotFoundComponent({
+  headerText = 'Page not found',
+  descriptionText = 'Check the URL and try again. (404)',
+}: NotFoundComponentProps) {
+  const { data: user } = useUser()
+
+  const handleGoHome = () => {
+    if (user) {
+      router.navigate({ to: '/goals'}) // logged-in home/dashboard
+    } else {
+      router.navigate({ to: '/'}) // public landing page
+    }
+  }
+  
+  const router = useRouter();
+
+  return (
+    <div className="flex flex-col gap-4 pt-18 items-center">
+      <FileQuestion size={`64px`} strokeWidth={2.5} />
+      <div>
+        <h2 className="text-base font-black text-center">{headerText}</h2>
+        <p className="text-sm font-normal text-center">{descriptionText}</p>
+      </div>
+      <div className="flex flex-row gap-2">
+        <Button onClick={handleGoHome}>Go Home</Button>
+      </div>
+    </div>
+  )
+}
+
+export { NotFoundComponent }

--- a/apps/client/src/components/custom/NotFoundComponent.tsx
+++ b/apps/client/src/components/custom/NotFoundComponent.tsx
@@ -16,13 +16,13 @@ function NotFoundComponent({
 
   const handleGoHome = () => {
     if (user) {
-      router.navigate({ to: '/goals'}) // logged-in home/dashboard
+      router.navigate({ to: '/goals' }) // logged-in home/dashboard
     } else {
-      router.navigate({ to: '/'}) // public landing page
+      router.navigate({ to: '/' }) // public landing page
     }
   }
-  
-  const router = useRouter();
+
+  const router = useRouter()
 
   return (
     <div className="flex flex-col gap-4 pt-18 items-center">

--- a/apps/client/src/components/custom/NotFoundComponent.tsx
+++ b/apps/client/src/components/custom/NotFoundComponent.tsx
@@ -1,6 +1,6 @@
 import { FileQuestion } from 'lucide-react'
-import { Button } from '@/components/ui/button'
 import { useRouter } from '@tanstack/react-router'
+import { Button } from '@/components/ui/button'
 import { useUser } from '@/apis/UserApi'
 
 interface NotFoundComponentProps {

--- a/apps/client/src/components/custom/formComponents.tsx
+++ b/apps/client/src/components/custom/formComponents.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/components/ui/radio-group'
 import { Label } from '@/components/ui/label'
 import { cn } from '@/lib/utils'
+import { Spinner } from '../ui/spinner'
 
 export const StandardIcons: Array<IconName> = [
   'biceps-flexed',
@@ -93,6 +94,7 @@ export function SubscribeButton({ label, variant }: SubscribeButtonProps) {
     <form.Subscribe selector={(state) => state.isSubmitting}>
       {(isSubmitting) => (
         <Button type="submit" disabled={isSubmitting} variant={variant}>
+          {isSubmitting && <Spinner data-icon="inline-start" className="mr-2" />}
           {label}
         </Button>
       )}

--- a/apps/client/src/components/custom/formComponents.tsx
+++ b/apps/client/src/components/custom/formComponents.tsx
@@ -94,7 +94,7 @@ export function SubscribeButton({ label, variant }: SubscribeButtonProps) {
     <form.Subscribe selector={(state) => state.isSubmitting}>
       {(isSubmitting) => (
         <Button type="submit" disabled={isSubmitting} variant={variant}>
-          {isSubmitting && <Spinner data-icon="inline-start" className="mr-2" />}
+          {isSubmitting && <Spinner data-icon="inline-start" />}
           {label}
         </Button>
       )}

--- a/apps/client/src/components/custom/formComponents.tsx
+++ b/apps/client/src/components/custom/formComponents.tsx
@@ -4,6 +4,7 @@ import { DynamicIcon } from 'lucide-react/dynamic'
 import { useState } from 'react'
 import { Eye, EyeOff } from 'lucide-react'
 import { useFieldContext, useFormContext } from '../../hooks/form-context'
+import { Spinner } from '../ui/spinner'
 import type { ChangeEvent } from 'react'
 import type { IconName } from 'lucide-react/dynamic'
 
@@ -21,7 +22,6 @@ import {
 } from '@/components/ui/radio-group'
 import { Label } from '@/components/ui/label'
 import { cn } from '@/lib/utils'
-import { Spinner } from '../ui/spinner'
 
 export const StandardIcons: Array<IconName> = [
   'biceps-flexed',

--- a/apps/client/src/components/ui/skeleton.tsx
+++ b/apps/client/src/components/ui/skeleton.tsx
@@ -4,7 +4,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="skeleton"
-      className={cn('bg-accent animate-pulse rounded-md', className)}
+      className={cn('bg-neutral-100 animate-pulse rounded-md', className)}
       {...props}
     />
   )

--- a/apps/client/src/components/ui/skeleton.tsx
+++ b/apps/client/src/components/ui/skeleton.tsx
@@ -4,7 +4,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="skeleton"
-      className={cn('bg-neutral-100 animate-pulse rounded-md', className)}
+      className={cn('bg-neutral-200 animate-pulse rounded-md', className)}
       {...props}
     />
   )

--- a/apps/client/src/components/ui/sonner.tsx
+++ b/apps/client/src/components/ui/sonner.tsx
@@ -1,0 +1,38 @@
+import {
+  CircleCheckIcon,
+  InfoIcon,
+  Loader2Icon,
+  OctagonXIcon,
+  TriangleAlertIcon,
+} from "lucide-react"
+import { useTheme } from "next-themes"
+import { Toaster as Sonner, type ToasterProps } from "sonner"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      icons={{
+        success: <CircleCheckIcon className="size-4" />,
+        info: <InfoIcon className="size-4" />,
+        warning: <TriangleAlertIcon className="size-4" />,
+        error: <OctagonXIcon className="size-4" />,
+        loading: <Loader2Icon className="size-4 animate-spin" />,
+      }}
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+          "--border-radius": "var(--radius)",
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/apps/client/src/components/ui/sonner.tsx
+++ b/apps/client/src/components/ui/sonner.tsx
@@ -4,17 +4,17 @@ import {
   Loader2Icon,
   OctagonXIcon,
   TriangleAlertIcon,
-} from "lucide-react"
-import { useTheme } from "next-themes"
-import { Toaster as Sonner  } from "sonner"
-import type {ToasterProps} from "sonner";
+} from 'lucide-react'
+import { useTheme } from 'next-themes'
+import { Toaster as Sonner } from 'sonner'
+import type { ToasterProps } from 'sonner'
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = "system" } = useTheme()
+  const { theme = 'system' } = useTheme()
 
   return (
     <Sonner
-      theme={theme as ToasterProps["theme"]}
+      theme={theme as ToasterProps['theme']}
       className="toaster group"
       icons={{
         success: <CircleCheckIcon className="size-4" />,
@@ -25,10 +25,10 @@ const Toaster = ({ ...props }: ToasterProps) => {
       }}
       style={
         {
-          "--normal-bg": "var(--popover)",
-          "--normal-text": "var(--popover-foreground)",
-          "--normal-border": "var(--border)",
-          "--border-radius": "var(--radius)",
+          '--normal-bg': 'var(--popover)',
+          '--normal-text': 'var(--popover-foreground)',
+          '--normal-border': 'var(--border)',
+          '--border-radius': 'var(--radius)',
         } as React.CSSProperties
       }
       {...props}

--- a/apps/client/src/components/ui/sonner.tsx
+++ b/apps/client/src/components/ui/sonner.tsx
@@ -6,7 +6,8 @@ import {
   TriangleAlertIcon,
 } from "lucide-react"
 import { useTheme } from "next-themes"
-import { Toaster as Sonner, type ToasterProps } from "sonner"
+import { Toaster as Sonner  } from "sonner"
+import type {ToasterProps} from "sonner";
 
 const Toaster = ({ ...props }: ToasterProps) => {
   const { theme = "system" } = useTheme()

--- a/apps/client/src/components/ui/spinner.tsx
+++ b/apps/client/src/components/ui/spinner.tsx
@@ -1,13 +1,13 @@
-import { Loader2Icon } from "lucide-react"
+import { Loader2Icon } from 'lucide-react'
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils'
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+function Spinner({ className, ...props }: React.ComponentProps<'svg'>) {
   return (
     <Loader2Icon
       role="status"
       aria-label="Loading"
-      className={cn("size-4 animate-spin", className)}
+      className={cn('size-4 animate-spin', className)}
       {...props}
     />
   )

--- a/apps/client/src/components/ui/spinner.tsx
+++ b/apps/client/src/components/ui/spinner.tsx
@@ -1,0 +1,16 @@
+import { Loader2Icon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+  return (
+    <Loader2Icon
+      role="status"
+      aria-label="Loading"
+      className={cn("size-4 animate-spin", className)}
+      {...props}
+    />
+  )
+}
+
+export { Spinner }

--- a/apps/client/src/features/goals/EntryCreatePage.tsx
+++ b/apps/client/src/features/goals/EntryCreatePage.tsx
@@ -18,10 +18,6 @@ import {
 } from '../../apis/GoalApi'
 import type { GoalEntryResponse } from '@habit-tracker/validation-schemas'
 import { TopBarClose } from '@/components/custom/TopBar'
-import {
-  ErrorDialogCategory,
-  ErrorDialogComponent,
-} from '@/components/custom/ErrorComponents'
 import { capitalizeFirstLetter } from '@/lib/stringUtils'
 import { Button } from '@/components/ui/button'
 import { useCurrentYear } from '@/hooks/useCurrentDate'
@@ -68,10 +64,6 @@ const EntryForm: React.FC<EntryFormProps> = ({
   const { mutate: updateGoalEntryMutateFn } = useUpdateGoalEntryMutation()
   const { mutate: deleteGoalEntryMutateFn } = useDeleteGoalEntryMutation()
 
-  const [displayedError, setDisplayedError] = useState<
-    { category: ErrorDialogCategory; error: Error } | undefined
-  >(undefined)
-
   const handleDelete = () => {
     if (defaultValues?.id) {
       deleteGoalEntryMutateFn(
@@ -81,12 +73,6 @@ const EntryForm: React.FC<EntryFormProps> = ({
         },
         {
           onSuccess: () => navigate({ to: '/goals' }),
-          onError: (error) => {
-            setDisplayedError({
-              error: error,
-              category: ErrorDialogCategory.DeleteFailed,
-            })
-          },
         },
       )
     }
@@ -109,11 +95,6 @@ const EntryForm: React.FC<EntryFormProps> = ({
           { goalId: goalId, createDto: parsed },
           {
             onSuccess: () => navigate({ to: '/goals' }),
-            onError: (error) =>
-              setDisplayedError({
-                error: error,
-                category: ErrorDialogCategory.FormSubmissionFailed,
-              }),
           },
         )
       } else {
@@ -122,11 +103,6 @@ const EntryForm: React.FC<EntryFormProps> = ({
             { goalId: goalId, entryId: defaultValues.id, updateDto: parsed },
             {
               onSuccess: () => navigate({ to: '/goals' }),
-              onError: (error) =>
-                setDisplayedError({
-                  error: error,
-                  category: ErrorDialogCategory.FormSubmissionFailed,
-                }),
             },
           )
         }
@@ -193,15 +169,6 @@ const EntryForm: React.FC<EntryFormProps> = ({
           </form.AppForm>
         </div>
       </form>
-      {displayedError && (
-        <ErrorDialogComponent
-          error={displayedError.error}
-          category={displayedError.category}
-          onClose={() => {
-            setDisplayedError(undefined)
-          }}
-        />
-      )}
     </div>
   )
 }
@@ -222,6 +189,7 @@ export function EntryCreatePage() {
 
   return (
     <>
+    {/* TODOs #12 handle loading + goal error better */}
       {!goalIsLoading && goalData && (
         <EntryForm
           isCreate={true}
@@ -265,6 +233,7 @@ export function EntryEditPage() {
 
   return (
     <>
+    {/* TODOs #12 handle loading + goal error */}
       {goalIsLoading && <div>Loading...</div>}
       {goalError && <div>{goalError.message}</div>}
       {displayEntryForm && (

--- a/apps/client/src/features/goals/EntryCreatePage.tsx
+++ b/apps/client/src/features/goals/EntryCreatePage.tsx
@@ -20,7 +20,11 @@ import { TopBarClose } from '@/components/custom/TopBar'
 import { capitalizeFirstLetter } from '@/lib/stringUtils'
 import { Button } from '@/components/ui/button'
 import { useCurrentYear } from '@/hooks/useCurrentDate'
-import { ErrorBodyComponent, ErrorBodyComponentPosition, ErrorBodyComponentSize } from '@/components/custom/ErrorComponents'
+import {
+  ErrorBodyComponent,
+  ErrorBodyComponentPosition,
+  ErrorBodyComponentSize,
+} from '@/components/custom/ErrorComponents'
 import { Spinner } from '@/components/ui/spinner'
 
 interface EntryFormProps {
@@ -30,7 +34,7 @@ interface EntryFormProps {
   goalUnit: string
   entryDate?: Date
   defaultValues?: GoalEntryResponse
-  closeCallback: () => void;
+  closeCallback: () => void
 }
 
 const EntryForm: React.FC<EntryFormProps> = ({
@@ -73,7 +77,7 @@ const EntryForm: React.FC<EntryFormProps> = ({
           entryId: defaultValues.id,
         },
         {
-          onSuccess: closeCallback
+          onSuccess: closeCallback,
         },
       )
     }
@@ -95,7 +99,7 @@ const EntryForm: React.FC<EntryFormProps> = ({
         createGoalEntryMutateFn(
           { goalId: goalId, createDto: parsed },
           {
-            onSuccess: closeCallback
+            onSuccess: closeCallback,
           },
         )
       } else {
@@ -103,7 +107,7 @@ const EntryForm: React.FC<EntryFormProps> = ({
           updateGoalEntryMutateFn(
             { goalId: goalId, entryId: defaultValues.id, updateDto: parsed },
             {
-              onSuccess: closeCallback
+              onSuccess: closeCallback,
             },
           )
         }
@@ -173,12 +177,7 @@ export function EntryCreatePage() {
   const dateStr = locationState.date
   const date = dateStr ? new Date(dateStr) : undefined
 
-  const {
-    data,
-    isLoading,
-    error,
-    refetch: goalRefetch
-  } = useGoal(goalId)
+  const { data, isLoading, error, refetch: goalRefetch } = useGoal(goalId)
 
   const navigateToGoals = () => {
     navigate({ to: '/goals' })
@@ -186,23 +185,32 @@ export function EntryCreatePage() {
 
   return (
     <div className="flex flex-col gap-3">
-      <TopBarClose title='Create Entry' closeCallback={navigateToGoals} />
-      {isLoading && <div className="flex justify-center items-center w-full h-full">
-        <Spinner className="size-28" />
-      </div>}
-      {error && <ErrorBodyComponent error={error} size={ErrorBodyComponentSize.Small} position={ErrorBodyComponentPosition.Centered} onRefreshClick={() => goalRefetch()} />}
-      {!isLoading && !error && data && <EntryForm
-        isCreate={true}
-        goalId={data.id}
-        goalType={data.goalType}
-        goalUnit={
-          data.goalType === GoalQuantifyType.Numeric
-            ? data.numericUnit
-            : ''
-        }
-        entryDate={date}
-        closeCallback={navigateToGoals}
-      />}
+      <TopBarClose title="Create Entry" closeCallback={navigateToGoals} />
+      {isLoading && (
+        <div className="flex justify-center items-center w-full h-full">
+          <Spinner className="size-28" />
+        </div>
+      )}
+      {error && (
+        <ErrorBodyComponent
+          error={error}
+          size={ErrorBodyComponentSize.Small}
+          position={ErrorBodyComponentPosition.Centered}
+          onRefreshClick={() => goalRefetch()}
+        />
+      )}
+      {!isLoading && !error && data && (
+        <EntryForm
+          isCreate={true}
+          goalId={data.id}
+          goalType={data.goalType}
+          goalUnit={
+            data.goalType === GoalQuantifyType.Numeric ? data.numericUnit : ''
+          }
+          entryDate={date}
+          closeCallback={navigateToGoals}
+        />
+      )}
     </div>
   )
 }
@@ -227,8 +235,8 @@ export function EntryEditPage() {
     navigate({ to: '/goals' })
   }
 
-  const isLoading = goalIsLoading || entryIsLoading;
-  const error = goalError || entryError;
+  const isLoading = goalIsLoading || entryIsLoading
+  const error = goalError || entryError
   const displayForm =
     !goalIsLoading &&
     !goalError &&
@@ -239,23 +247,34 @@ export function EntryEditPage() {
 
   return (
     <div className="flex flex-col gap-3">
-      <TopBarClose title='Edit Entry' closeCallback={navigateToGoals} />
-      {isLoading && <div className="flex justify-center items-center w-full h-full">
-        <Spinner className="size-28" />
-      </div>}
-      {error && <ErrorBodyComponent error={error} size={ErrorBodyComponentSize.Small} position={ErrorBodyComponentPosition.Centered} onRefreshClick={() => goalRefetch()} />}
-      {displayForm && <EntryForm
-        isCreate={false}
-        goalId={Number(goalId)}
-        goalType={goalData.goalType}
-        goalUnit={
-          goalData.goalType === GoalQuantifyType.Numeric
-            ? goalData.numericUnit
-            : ''
-        }
-        defaultValues={entryData}
-        closeCallback={navigateToGoals}
-      />}
+      <TopBarClose title="Edit Entry" closeCallback={navigateToGoals} />
+      {isLoading && (
+        <div className="flex justify-center items-center w-full h-full">
+          <Spinner className="size-28" />
+        </div>
+      )}
+      {error && (
+        <ErrorBodyComponent
+          error={error}
+          size={ErrorBodyComponentSize.Small}
+          position={ErrorBodyComponentPosition.Centered}
+          onRefreshClick={() => goalRefetch()}
+        />
+      )}
+      {displayForm && (
+        <EntryForm
+          isCreate={false}
+          goalId={Number(goalId)}
+          goalType={goalData.goalType}
+          goalUnit={
+            goalData.goalType === GoalQuantifyType.Numeric
+              ? goalData.numericUnit
+              : ''
+          }
+          defaultValues={entryData}
+          closeCallback={navigateToGoals}
+        />
+      )}
     </div>
   )
 }

--- a/apps/client/src/features/goals/EntryCreatePage.tsx
+++ b/apps/client/src/features/goals/EntryCreatePage.tsx
@@ -21,6 +21,8 @@ import { TopBarClose } from '@/components/custom/TopBar'
 import { capitalizeFirstLetter } from '@/lib/stringUtils'
 import { Button } from '@/components/ui/button'
 import { useCurrentYear } from '@/hooks/useCurrentDate'
+import { ErrorBodyComponent, ErrorBodyComponentPosition, ErrorBodyComponentSize } from '@/components/custom/ErrorComponents'
+import { Spinner } from '@/components/ui/spinner'
 
 interface EntryFormProps {
   isCreate: boolean
@@ -29,6 +31,7 @@ interface EntryFormProps {
   goalUnit: string
   entryDate?: Date
   defaultValues?: GoalEntryResponse
+  closeCallback: () => void;
 }
 
 const EntryForm: React.FC<EntryFormProps> = ({
@@ -38,9 +41,8 @@ const EntryForm: React.FC<EntryFormProps> = ({
   goalUnit,
   entryDate,
   defaultValues,
+  closeCallback,
 }) => {
-  const navigate = useNavigate()
-
   const currentYear = useCurrentYear()
   const entryDatePlaceholder = `e.g. 01 January ${currentYear}`
 
@@ -72,7 +74,7 @@ const EntryForm: React.FC<EntryFormProps> = ({
           entryId: defaultValues.id,
         },
         {
-          onSuccess: () => navigate({ to: '/goals' }),
+          onSuccess: closeCallback
         },
       )
     }
@@ -94,7 +96,7 @@ const EntryForm: React.FC<EntryFormProps> = ({
         createGoalEntryMutateFn(
           { goalId: goalId, createDto: parsed },
           {
-            onSuccess: () => navigate({ to: '/goals' }),
+            onSuccess: closeCallback
           },
         )
       } else {
@@ -102,7 +104,7 @@ const EntryForm: React.FC<EntryFormProps> = ({
           updateGoalEntryMutateFn(
             { goalId: goalId, entryId: defaultValues.id, updateDto: parsed },
             {
-              onSuccess: () => navigate({ to: '/goals' }),
+              onSuccess: closeCallback
             },
           )
         }
@@ -111,69 +113,60 @@ const EntryForm: React.FC<EntryFormProps> = ({
   })
 
   return (
-    <div className="flex flex-col gap-3">
-      {/* Topbar config */}
-      <TopBarClose
-        title={isCreate ? 'Create Entry' : 'Edit Entry'}
-        closeCallback={() => {
-          navigate({ to: '/goals' })
-        }}
-      />
-      {/* Form controls container */}
-      <form
-        onSubmit={(e) => {
-          e.preventDefault()
-          e.stopPropagation()
-          form.handleSubmit()
-        }}
-        className="space-y-6"
-      >
-        <form.AppField name="entryDate">
-          {(field) => (
-            <field.DateField label="Date" placeholder={entryDatePlaceholder} />
-          )}
-        </form.AppField>
+    <form
+      onSubmit={(e) => {
+        e.preventDefault()
+        e.stopPropagation()
+        form.handleSubmit()
+      }}
+      className="space-y-6"
+    >
+      <form.AppField name="entryDate">
+        {(field) => (
+          <field.DateField label="Date" placeholder={entryDatePlaceholder} />
+        )}
+      </form.AppField>
 
-        <form.AppField name="note">
+      <form.AppField name="note">
+        {(field) => (
+          <field.TextField
+            label="Notes"
+            placeholder="Optional. Add more details if needed"
+          />
+        )}
+      </form.AppField>
+
+      {goalType === GoalQuantifyType.Numeric && (
+        <form.AppField name="numericValue">
           {(field) => (
-            <field.TextField
-              label="Notes"
-              placeholder="Optional. Add more details if needed"
+            <field.NumberField
+              label={capitalizeFirstLetter(goalUnit)}
+              placeholder="e.g. 30"
             />
           )}
         </form.AppField>
+      )}
 
-        {goalType === GoalQuantifyType.Numeric && (
-          <form.AppField name="numericValue">
-            {(field) => (
-              <field.NumberField
-                label={capitalizeFirstLetter(goalUnit)}
-                placeholder="e.g. 30"
-              />
-            )}
-          </form.AppField>
-        )}
-
-        <div className="flex justify-end">
-          <form.AppForm>
-            {!isCreate && (
-              <Button
-                type="button"
-                variant={'ghostDestructive'}
-                onClick={handleDelete}
-              >
-                Delete
-              </Button>
-            )}
-            <form.SubscribeButton label={isCreate ? 'Create' : 'Save'} />
-          </form.AppForm>
-        </div>
-      </form>
-    </div>
+      <div className="flex justify-end">
+        <form.AppForm>
+          {!isCreate && (
+            <Button
+              type="button"
+              variant={'ghostDestructive'}
+              onClick={handleDelete}
+            >
+              Delete
+            </Button>
+          )}
+          <form.SubscribeButton label={isCreate ? 'Create' : 'Save'} />
+        </form.AppForm>
+      </div>
+    </form>
   )
 }
 
 export function EntryCreatePage() {
+  const navigate = useNavigate()
   const route = getRouteApi('/goals_/$goalId_/entries/create')
   const { goalId: goalId } = route.useParams()
 
@@ -182,33 +175,41 @@ export function EntryCreatePage() {
   const date = dateStr ? new Date(dateStr) : undefined
 
   const {
-    data: goalData,
-    isLoading: goalIsLoading,
-    error: goalError,
+    data,
+    isLoading,
+    error,
+    refetch: goalRefetch
   } = useGoal(goalId)
 
+  const navigateToGoals = () => {
+    navigate({ to: '/goals' })
+  }
+
   return (
-    <>
-    {/* TODOs #12 handle loading + goal error better */}
-      {!goalIsLoading && goalData && (
-        <EntryForm
-          isCreate={true}
-          goalId={goalData.id}
-          goalType={goalData.goalType}
-          goalUnit={
-            goalData.goalType === GoalQuantifyType.Numeric
-              ? goalData.numericUnit
-              : ''
-          }
-          entryDate={date}
-        />
-      )}
-      {goalError && 'Goal Error'}
-    </>
+    <div className="flex flex-col gap-3">
+      <TopBarClose title='Create Entry' closeCallback={navigateToGoals} />
+      {isLoading && <div className="flex justify-center items-center w-full h-full">
+        <Spinner className="size-28" />
+      </div>}
+      {error && <ErrorBodyComponent error={error} size={ErrorBodyComponentSize.Small} position={ErrorBodyComponentPosition.Centered} onRefreshClick={() => goalRefetch()} />}
+      {!isLoading && !error && data && <EntryForm
+        isCreate={true}
+        goalId={data.id}
+        goalType={data.goalType}
+        goalUnit={
+          data.goalType === GoalQuantifyType.Numeric
+            ? data.numericUnit
+            : ''
+        }
+        entryDate={date}
+        closeCallback={navigateToGoals}
+      />}
+    </div>
   )
 }
 
 export function EntryEditPage() {
+  const navigate = useNavigate()
   const route = getRouteApi('/goals_/$goalId_/entries_/$entryId/edit')
 
   const { goalId: goalId, entryId: entryId } = route.useParams()
@@ -223,7 +224,13 @@ export function EntryEditPage() {
     error: entryError,
   } = useGoalEntry(entryId)
 
-  const displayEntryForm =
+  const navigateToGoals = () => {
+    navigate({ to: '/goals' })
+  }
+
+  const isLoading = goalIsLoading || entryIsLoading;
+  const error = goalError || entryError;
+  const displayForm =
     !goalIsLoading &&
     !goalError &&
     goalData &&
@@ -232,23 +239,24 @@ export function EntryEditPage() {
     entryData
 
   return (
-    <>
-    {/* TODOs #12 handle loading + goal error */}
-      {goalIsLoading && <div>Loading...</div>}
-      {goalError && <div>{goalError.message}</div>}
-      {displayEntryForm && (
-        <EntryForm
-          isCreate={false}
-          goalId={Number(goalId)}
-          goalType={goalData.goalType}
-          goalUnit={
-            goalData.goalType === GoalQuantifyType.Numeric
-              ? goalData.numericUnit
-              : ''
-          }
-          defaultValues={entryData}
-        />
-      )}
-    </>
+    <div className="flex flex-col gap-3">
+      <TopBarClose title='Edit Entry' closeCallback={navigateToGoals} />
+      {isLoading && <div className="flex justify-center items-center w-full h-full">
+        <Spinner className="size-28" />
+      </div>}
+      {error && <ErrorBodyComponent error={error} size={ErrorBodyComponentSize.Small} position={ErrorBodyComponentPosition.Centered} onRefreshClick={() => goalRefetch()} />}
+      {displayForm && <EntryForm
+        isCreate={false}
+        goalId={Number(goalId)}
+        goalType={goalData.goalType}
+        goalUnit={
+          goalData.goalType === GoalQuantifyType.Numeric
+            ? goalData.numericUnit
+            : ''
+        }
+        defaultValues={entryData}
+        closeCallback={navigateToGoals}
+      />}
+    </div>
   )
 }

--- a/apps/client/src/features/goals/EntryCreatePage.tsx
+++ b/apps/client/src/features/goals/EntryCreatePage.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import {
   getRouteApi,
   useNavigate,

--- a/apps/client/src/features/goals/GoalCreatePage.tsx
+++ b/apps/client/src/features/goals/GoalCreatePage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import React, { useState } from 'react'
 import {
   getRouteApi,
   useCanGoBack,
@@ -26,10 +26,51 @@ import { Button } from '@/components/ui/button'
 import { DeleteDialog } from '@/components/custom/DialogComponents'
 import { Skeleton } from '@/components/ui/skeleton'
 import { ErrorBodyComponent } from '@/components/custom/ErrorComponents'
+import { useSmartBack } from '@/hooks/useSmartBack'
 
 // TODOs #11:
 // - Fix `value` prop on `input` should not be null. Consider using an empty string to clear the component or `undefined` for uncontrolled components.
 
+/**
+ * Private components
+ */
+
+
+/**
+ * Goal Page:
+ * Presentational layout component for page to display children
+ */
+interface GoalPageProps {
+  children: React.ReactNode
+}
+
+const GoalPage: React.FC<GoalPageProps> = ({ children }) => {
+  return <div className="flex flex-col gap-3">
+    {children}
+  </div>
+}
+
+/**
+ * Goal Header:
+ * Contains title create/ edit + back button
+ */
+interface GoalHeaderProps {
+  isCreate: boolean
+}
+
+const GoalHeader: React.FC<GoalHeaderProps> = ({ isCreate }) => {
+  const navigateBack = useSmartBack();
+
+  return <TopBarClose
+    title={isCreate ? 'Create Goal' : 'Edit Goal'}
+    closeCallback={navigateBack}
+  />
+}
+
+/**
+ * Goal Form:
+ * Contains goal create/ edit fields + cancel/ save buttons
+ */
 interface GoalFormProps {
   isCreate: boolean
   defaultValues?: GoalResponse
@@ -37,8 +78,7 @@ interface GoalFormProps {
 
 const GoalForm: React.FC<GoalFormProps> = ({ isCreate, defaultValues }) => {
   const navigate = useNavigate()
-  const router = useRouter()
-  const canGoBack = useCanGoBack()
+  const navigateBack = useSmartBack();
 
   const initialValues =
     defaultValues ||
@@ -56,14 +96,6 @@ const GoalForm: React.FC<GoalFormProps> = ({ isCreate, defaultValues }) => {
   const { mutate: createGoalMutateFn } = useCreateGoalMutation()
   const { mutate: updateGoalMutateFn } = useUpdateGoalMutation()
   const { mutate: deleteGoalMutateFn } = useDeleteGoalMutation()
-
-  const navigateBack = () => {
-    if (canGoBack) {
-      router.history.back()
-    } else {
-      navigate({ to: '/goals' })
-    }
-  }
 
   const form = useAppForm({
     defaultValues: initialValues,
@@ -97,161 +129,170 @@ const GoalForm: React.FC<GoalFormProps> = ({ isCreate, defaultValues }) => {
   }
 
   return (
-    <div className="flex flex-col gap-3">
-      {/* Topbar config */}
-      <TopBarClose
-        title={isCreate ? 'Create Goal' : 'Edit Goal'}
-        closeCallback={navigateBack}
-      />
-      {/* Form controls container */}
-      <form
-        onSubmit={(e) => {
-          e.preventDefault()
-          e.stopPropagation()
-          form.handleSubmit()
-        }}
-        className="space-y-6"
-      >
-        <form.AppField name="title">
-          {(field) => (
-            <field.TextField
-              label="Title"
-              placeholder="e.g. Run a half marathon"
-            />
-          )}
-        </form.AppField>
+  <form
+    onSubmit={(e) => {
+      e.preventDefault()
+      e.stopPropagation()
+      form.handleSubmit()
+    }}
+    className="space-y-6"
+  >
+    <form.AppField name="title">
+      {(field) => (
+        <field.TextField
+          label="Title"
+          placeholder="e.g. Run a half marathon"
+        />
+      )}
+    </form.AppField>
 
-        <form.AppField name="description">
-          {(field) => (
-            <field.TextField
-              label="Description"
-              placeholder="Optional. Add more details if needed"
-            />
-          )}
-        </form.AppField>
+    <form.AppField name="description">
+      {(field) => (
+        <field.TextField
+          label="Description"
+          placeholder="Optional. Add more details if needed"
+        />
+      )}
+    </form.AppField>
 
-        {/* Goal type. Note: hiding when editing goal, as cannot convert goal entries between the two types */}
-        {isCreate && (
-          <form.AppField name="goalType">
-            {(field) => (
-              <field.RadioGroup
-                label="Goal Type"
-                values={[
-                  { label: 'Numeric', value: GoalQuantifyType.Numeric },
-                  { label: 'Boolean', value: GoalQuantifyType.Boolean },
-                ]}
-              />
-            )}
-          </form.AppField>
+    {/* Goal type. Note: hiding when editing goal, as cannot convert goal entries between the two types */}
+    {isCreate && (
+      <form.AppField name="goalType">
+        {(field) => (
+          <field.RadioGroup
+            label="Goal Type"
+            values={[
+              { label: 'Numeric', value: GoalQuantifyType.Numeric },
+              { label: 'Boolean', value: GoalQuantifyType.Boolean },
+            ]}
+          />
         )}
+      </form.AppField>
+    )}
 
-        <form.Subscribe selector={(state) => state.values.goalType}>
-          {(goalType) => {
-            if (goalType === GoalQuantifyType.Numeric) {
-              return (
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                  <form.AppField name="numericTarget">
-                    {(field) => (
-                      <field.NumberField
-                        label="Daily Target"
-                        placeholder="e.g. 30"
-                      />
-                    )}
-                  </form.AppField>
-                  <form.AppField name="numericUnit">
-                    {(field) => (
-                      <field.TextField
-                        label="Units"
-                        placeholder="e.g. km, hours, sessions"
-                      />
-                    )}
-                  </form.AppField>
-                </div>
-              )
-            } else {
-              return null
-            }
-          }}
-        </form.Subscribe>
+    <form.Subscribe selector={(state) => state.values.goalType}>
+      {(goalType) => {
+        if (goalType === GoalQuantifyType.Numeric) {
+          return (
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <form.AppField name="numericTarget">
+                {(field) => (
+                  <field.NumberField
+                    label="Daily Target"
+                    placeholder="e.g. 30"
+                  />
+                )}
+              </form.AppField>
+              <form.AppField name="numericUnit">
+                {(field) => (
+                  <field.TextField
+                    label="Units"
+                    placeholder="e.g. km, hours, sessions"
+                  />
+                )}
+              </form.AppField>
+            </div>
+          )
+        } else {
+          return null
+        }
+      }}
+    </form.Subscribe>
 
-        <form.AppField name="publicity">
-          {(field) => (
-            <field.Select
-              label="Privacy"
-              values={[
-                { label: 'Public', value: GoalPublicityType.Public },
-                { label: 'Private', value: GoalPublicityType.Private },
-              ]}
-              placeholder="Select a publicity type"
-            />
-          )}
-        </form.AppField>
+    <form.AppField name="publicity">
+      {(field) => (
+        <field.Select
+          label="Privacy"
+          values={[
+            { label: 'Public', value: GoalPublicityType.Public },
+            { label: 'Private', value: GoalPublicityType.Private },
+          ]}
+          placeholder="Select a publicity type"
+        />
+      )}
+    </form.AppField>
 
-        {/* Color selection */}
-        <form.AppField name="colour">
-          {(field) => <field.ColourSelect label="Colour" />}
-        </form.AppField>
+    {/* Color selection */}
+    <form.AppField name="colour">
+      {(field) => <field.ColourSelect label="Colour" />}
+    </form.AppField>
 
-        {/* Icon selection */}
-        <form.AppField name="icon">
-          {(field) => <field.IconSelect label="Icon" />}
-        </form.AppField>
+    {/* Icon selection */}
+    <form.AppField name="icon">
+      {(field) => <field.IconSelect label="Icon" />}
+    </form.AppField>
 
-        <div className="flex flex-row gap-1.5 justify-end">
-          <form.AppForm>
-            {!isCreate && (
-              <DeleteDialog
-                title="Delete Goal"
-                description="Deleting a goal is permanent. This will also delete any associated entries. Are you sure you want to delete this goal?"
-                onDelete={handleDelete}
-              >
-                <Button type="button" variant={'ghostDestructive'}>
-                  Delete
-                </Button>
-              </DeleteDialog>
-            )}
-            <form.SubscribeButton label={isCreate ? 'Create' : 'Save'} />
-          </form.AppForm>
-        </div>
-      </form>
+    <div className="flex flex-row gap-1.5 justify-end">
+      <form.AppForm>
+        {!isCreate && (
+          <DeleteDialog
+            title="Delete Goal"
+            description="Deleting a goal is permanent. This will also delete any associated entries. Are you sure you want to delete this goal?"
+            onDelete={handleDelete}
+          >
+            <Button type="button" variant={'ghostDestructive'}>
+              Delete
+            </Button>
+          </DeleteDialog>
+        )}
+        <form.SubscribeButton label={isCreate ? 'Create' : 'Save'} />
+      </form.AppForm>
     </div>
+  </form>
   )
 }
 
 export const SkeletonGoalForm: React.FC = () => {
   return (
-    <div className="flex flex-col gap-3">
-      {/* Topbar skeleton */}
-      <Skeleton className="h-12 w-full rounded-md" />
-      {/* Form skeleton */}
-      <div className="space-y-6">
-        {/* Title */}
+    <div className="space-y-6">
+      {/* Title */}
+      <Skeleton className="h-10 w-full" />
+      {/* Description */}
+      <Skeleton className="h-20 w-full" />
+      {/* Numeric fields grid */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <Skeleton className="h-10 w-full" />
-        {/* Description */}
-        <Skeleton className="h-20 w-full" />
-        {/* Numeric fields grid */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <Skeleton className="h-10 w-full" />
-          <Skeleton className="h-10 w-full" />
-        </div>
-        {/* Publicity */}
         <Skeleton className="h-10 w-full" />
-        {/* Colour */}
-        <Skeleton className="h-10 w-full" />
-        {/* Icon */}
-        <Skeleton className="h-10 w-full" />
-        {/* Buttons */}
-        <div className="flex flex-row gap-1.5 justify-end">
-          <Skeleton className="h-10 w-20" />
-          <Skeleton className="h-10 w-20" />
-        </div>
+      </div>
+      {/* Publicity */}
+      <Skeleton className="h-10 w-full" />
+      {/* Colour */}
+      <Skeleton className="h-10 w-full" />
+      {/* Icon */}
+      <Skeleton className="h-10 w-full" />
+      {/* Buttons */}
+      <div className="flex flex-row gap-1.5 justify-end">
+        <Skeleton className="h-10 w-20" />
+        <Skeleton className="h-10 w-20" />
       </div>
     </div>
   )
 }
 
+
+/**
+ * Public components
+ */
+
+export function SkeletonGoalCreatePage() {
+  return <GoalPage>
+    <GoalHeader isCreate={true} />
+    <SkeletonGoalForm />
+  </GoalPage>
+}
+
+export function SkeletonGoalEditPage() {
+  return <GoalPage>
+    <GoalHeader isCreate={false} />
+    <SkeletonGoalForm />
+  </GoalPage>
+}
+
 export function GoalCreatePage() {
-  return <GoalForm isCreate={true} />
+  return <GoalPage>
+    <GoalHeader isCreate={true} />
+    <GoalForm isCreate={true}/>
+  </GoalPage>
 }
 
 export function GoalEditPage() {
@@ -261,12 +302,14 @@ export function GoalEditPage() {
   const navigate = useNavigate()
 
   return (
-    <>
+    <GoalPage>
+      <GoalHeader isCreate={false} />
     {/* TODOs #12 update so that
       - Message is more unique (not just generic Oops! But related to error e.g. Not Found)
-      - Have topbar always be shown as static, across both Error + Loading component
     */}
-      {isLoading && <SkeletonGoalForm />}
+      {isLoading && 
+        <SkeletonGoalForm />
+      }
       {error && (
         <ErrorBodyComponent
           error={error}
@@ -279,6 +322,6 @@ export function GoalEditPage() {
       {!isLoading && !error && (
         <GoalForm isCreate={false} defaultValues={data} />
       )}
-    </>
+    </GoalPage>
   )
 }

--- a/apps/client/src/features/goals/GoalCreatePage.tsx
+++ b/apps/client/src/features/goals/GoalCreatePage.tsx
@@ -304,9 +304,6 @@ export function GoalEditPage() {
   return (
     <GoalPage>
       <GoalHeader isCreate={false} />
-    {/* TODOs #12 update so that
-      - Message is more unique (not just generic Oops! But related to error e.g. Not Found)
-    */}
       {isLoading && 
         <SkeletonGoalForm />
       }

--- a/apps/client/src/features/goals/GoalCreatePage.tsx
+++ b/apps/client/src/features/goals/GoalCreatePage.tsx
@@ -24,6 +24,8 @@ import type {
 import { TopBarClose } from '@/components/custom/TopBar'
 import { Button } from '@/components/ui/button'
 import { DeleteDialog } from '@/components/custom/DialogComponents'
+import { Skeleton } from '@/components/ui/skeleton'
+import { ErrorBodyComponent } from '@/components/custom/ErrorComponents'
 
 // TODOs #11:
 // - Fix `value` prop on `input` should not be null. Consider using an empty string to clear the component or `undefined` for uncontrolled components.
@@ -216,6 +218,38 @@ const GoalForm: React.FC<GoalFormProps> = ({ isCreate, defaultValues }) => {
   )
 }
 
+export const SkeletonGoalForm: React.FC = () => {
+  return (
+    <div className="flex flex-col gap-3">
+      {/* Topbar skeleton */}
+      <Skeleton className="h-12 w-full rounded-md" />
+      {/* Form skeleton */}
+      <div className="space-y-6">
+        {/* Title */}
+        <Skeleton className="h-10 w-full" />
+        {/* Description */}
+        <Skeleton className="h-20 w-full" />
+        {/* Numeric fields grid */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+        </div>
+        {/* Publicity */}
+        <Skeleton className="h-10 w-full" />
+        {/* Colour */}
+        <Skeleton className="h-10 w-full" />
+        {/* Icon */}
+        <Skeleton className="h-10 w-full" />
+        {/* Buttons */}
+        <div className="flex flex-row gap-1.5 justify-end">
+          <Skeleton className="h-10 w-20" />
+          <Skeleton className="h-10 w-20" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
 export function GoalCreatePage() {
   return <GoalForm isCreate={true} />
 }
@@ -223,13 +257,25 @@ export function GoalCreatePage() {
 export function GoalEditPage() {
   const route = getRouteApi('/goals_/$goalId_/edit')
   const { goalId: goalId } = route.useParams()
-  const { data, isLoading, error } = useGoal(goalId)
+  const { data, isLoading, error, refetch } = useGoal(goalId)
+  const navigate = useNavigate()
 
   return (
     <>
-    {/* TODOs #12 update loading behavior + error display for when goal edit fails to get goal */}
-      {isLoading && <div>Loading...</div>}
-      {error && <div>{error.message}</div>}
+    {/* TODOs #12 update so that
+      - Message is more unique (not just generic Oops! But related to error e.g. Not Found)
+      - Have topbar always be shown as static, across both Error + Loading component
+    */}
+      {isLoading && <SkeletonGoalForm />}
+      {error && (
+        <ErrorBodyComponent
+          error={error}
+          onRefreshClick={() => refetch()}
+          onBackClick={() => {
+            navigate({ to: '/goals' })
+          }}
+        />
+      )}
       {!isLoading && !error && (
         <GoalForm isCreate={false} defaultValues={data} />
       )}

--- a/apps/client/src/features/goals/GoalCreatePage.tsx
+++ b/apps/client/src/features/goals/GoalCreatePage.tsx
@@ -22,10 +22,6 @@ import type {
   GoalResponse,
 } from '@habit-tracker/validation-schemas'
 import { TopBarClose } from '@/components/custom/TopBar'
-import {
-  ErrorDialogCategory,
-  ErrorDialogComponent,
-} from '@/components/custom/ErrorComponents'
 import { Button } from '@/components/ui/button'
 import { DeleteDialog } from '@/components/custom/DialogComponents'
 
@@ -59,10 +55,6 @@ const GoalForm: React.FC<GoalFormProps> = ({ isCreate, defaultValues }) => {
   const { mutate: updateGoalMutateFn } = useUpdateGoalMutation()
   const { mutate: deleteGoalMutateFn } = useDeleteGoalMutation()
 
-  const [displayedError, setDisplayedError] = useState<
-    { category: ErrorDialogCategory; error: Error } | undefined
-  >(undefined)
-
   const navigateBack = () => {
     if (canGoBack) {
       router.history.back()
@@ -80,11 +72,6 @@ const GoalForm: React.FC<GoalFormProps> = ({ isCreate, defaultValues }) => {
       if (isCreate) {
         createGoalMutateFn(value, {
           onSuccess: navigateBack,
-          onError: (error) =>
-            setDisplayedError({
-              error: error,
-              category: ErrorDialogCategory.FormSubmissionFailed,
-            }),
         })
       } else {
         if (defaultValues?.id) {
@@ -92,11 +79,6 @@ const GoalForm: React.FC<GoalFormProps> = ({ isCreate, defaultValues }) => {
             { id: defaultValues.id, update: value },
             {
               onSuccess: navigateBack,
-              onError: (error) =>
-                setDisplayedError({
-                  error: error,
-                  category: ErrorDialogCategory.FormSubmissionFailed,
-                }),
             },
           )
         }
@@ -108,11 +90,6 @@ const GoalForm: React.FC<GoalFormProps> = ({ isCreate, defaultValues }) => {
     if (defaultValues?.id) {
       deleteGoalMutateFn(defaultValues.id, {
         onSuccess: () => navigate({ to: '/goals' }),
-        onError: (error) =>
-          setDisplayedError({
-            error: error,
-            category: ErrorDialogCategory.DeleteFailed,
-          }),
       })
     }
   }
@@ -235,15 +212,6 @@ const GoalForm: React.FC<GoalFormProps> = ({ isCreate, defaultValues }) => {
           </form.AppForm>
         </div>
       </form>
-      {displayedError && (
-        <ErrorDialogComponent
-          error={displayedError.error}
-          category={displayedError.category}
-          onClose={() => {
-            setDisplayedError(undefined)
-          }}
-        />
-      )}
     </div>
   )
 }
@@ -259,6 +227,7 @@ export function GoalEditPage() {
 
   return (
     <>
+    {/* TODOs #12 update loading behavior + error display for when goal edit fails to get goal */}
       {isLoading && <div>Loading...</div>}
       {error && <div>{error.message}</div>}
       {!isLoading && !error && (

--- a/apps/client/src/features/goals/GoalCreatePage.tsx
+++ b/apps/client/src/features/goals/GoalCreatePage.tsx
@@ -120,11 +120,14 @@ const GoalForm: React.FC<GoalFormProps> = ({ isCreate, defaultValues }) => {
     },
   })
 
-  const handleDelete = () => {
-    if (defaultValues?.id) {
-      deleteGoalMutateFn(defaultValues.id, {
-        onSuccess: () => navigate({ to: '/goals' }),
-      })
+  const handleDelete = async () => {
+    if (!defaultValues?.id) return
+
+    try {
+      await deleteGoalMutateFn(defaultValues.id)
+      navigate({ to: '/goals' })
+    } catch (err) {
+      console.error(err)
     }
   }
 

--- a/apps/client/src/features/goals/GoalCreatePage.tsx
+++ b/apps/client/src/features/goals/GoalCreatePage.tsx
@@ -93,23 +93,23 @@ const GoalForm: React.FC<GoalFormProps> = ({ isCreate, defaultValues }) => {
       icon: '',
     } as CreateGoalDto)
 
-  const { mutate: createGoalMutateFn } = useCreateGoalMutation()
-  const { mutate: updateGoalMutateFn } = useUpdateGoalMutation()
-  const { mutate: deleteGoalMutateFn } = useDeleteGoalMutation()
+  const { mutateAsync: createGoalMutateFn } = useCreateGoalMutation()
+  const { mutateAsync: updateGoalMutateFn } = useUpdateGoalMutation()
+  const { mutateAsync: deleteGoalMutateFn } = useDeleteGoalMutation()
 
   const form = useAppForm({
     defaultValues: initialValues,
     validators: {
       onChange: CreateGoalSchema,
     },
-    onSubmit: ({ value }) => {
+    onSubmit: async ({ value }) => {
       if (isCreate) {
-        createGoalMutateFn(value, {
+        return createGoalMutateFn(value, {
           onSuccess: navigateBack,
         })
       } else {
         if (defaultValues?.id) {
-          updateGoalMutateFn(
+          return updateGoalMutateFn(
             { id: defaultValues.id, update: value },
             {
               onSuccess: navigateBack,

--- a/apps/client/src/features/goals/GoalCreatePage.tsx
+++ b/apps/client/src/features/goals/GoalCreatePage.tsx
@@ -1,8 +1,5 @@
 import React from 'react'
-import {
-  getRouteApi,
-  useNavigate,
-} from '@tanstack/react-router'
+import { getRouteApi, useNavigate } from '@tanstack/react-router'
 import {
   CreateGoalSchema,
   GoalPublicityType,
@@ -33,7 +30,6 @@ import { useSmartBack } from '@/hooks/useSmartBack'
  * Private components
  */
 
-
 /**
  * Goal Page:
  * Presentational layout component for page to display children
@@ -43,9 +39,7 @@ interface GoalPageProps {
 }
 
 const GoalPage: React.FC<GoalPageProps> = ({ children }) => {
-  return <div className="flex flex-col gap-3">
-    {children}
-  </div>
+  return <div className="flex flex-col gap-3">{children}</div>
 }
 
 /**
@@ -57,12 +51,14 @@ interface GoalHeaderProps {
 }
 
 const GoalHeader: React.FC<GoalHeaderProps> = ({ isCreate }) => {
-  const navigateBack = useSmartBack();
+  const navigateBack = useSmartBack()
 
-  return <TopBarClose
-    title={isCreate ? 'Create Goal' : 'Edit Goal'}
-    closeCallback={navigateBack}
-  />
+  return (
+    <TopBarClose
+      title={isCreate ? 'Create Goal' : 'Edit Goal'}
+      closeCallback={navigateBack}
+    />
+  )
 }
 
 /**
@@ -76,7 +72,7 @@ interface GoalFormProps {
 
 const GoalForm: React.FC<GoalFormProps> = ({ isCreate, defaultValues }) => {
   const navigate = useNavigate()
-  const navigateBack = useSmartBack();
+  const navigateBack = useSmartBack()
 
   const initialValues =
     defaultValues ||
@@ -130,116 +126,116 @@ const GoalForm: React.FC<GoalFormProps> = ({ isCreate, defaultValues }) => {
   }
 
   return (
-  <form
-    onSubmit={(e) => {
-      e.preventDefault()
-      e.stopPropagation()
-      form.handleSubmit()
-    }}
-    className="space-y-6"
-  >
-    <form.AppField name="title">
-      {(field) => (
-        <field.TextField
-          label="Title"
-          placeholder="e.g. Run a half marathon"
-        />
-      )}
-    </form.AppField>
-
-    <form.AppField name="description">
-      {(field) => (
-        <field.TextField
-          label="Description"
-          placeholder="Optional. Add more details if needed"
-        />
-      )}
-    </form.AppField>
-
-    {/* Goal type. Note: hiding when editing goal, as cannot convert goal entries between the two types */}
-    {isCreate && (
-      <form.AppField name="goalType">
+    <form
+      onSubmit={(e) => {
+        e.preventDefault()
+        e.stopPropagation()
+        form.handleSubmit()
+      }}
+      className="space-y-6"
+    >
+      <form.AppField name="title">
         {(field) => (
-          <field.RadioGroup
-            label="Goal Type"
-            values={[
-              { label: 'Numeric', value: GoalQuantifyType.Numeric },
-              { label: 'Boolean', value: GoalQuantifyType.Boolean },
-            ]}
+          <field.TextField
+            label="Title"
+            placeholder="e.g. Run a half marathon"
           />
         )}
       </form.AppField>
-    )}
 
-    <form.Subscribe selector={(state) => state.values.goalType}>
-      {(goalType) => {
-        if (goalType === GoalQuantifyType.Numeric) {
-          return (
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <form.AppField name="numericTarget">
-                {(field) => (
-                  <field.NumberField
-                    label="Daily Target"
-                    placeholder="e.g. 30"
-                  />
-                )}
-              </form.AppField>
-              <form.AppField name="numericUnit">
-                {(field) => (
-                  <field.TextField
-                    label="Units"
-                    placeholder="e.g. km, hours, sessions"
-                  />
-                )}
-              </form.AppField>
-            </div>
-          )
-        } else {
-          return null
-        }
-      }}
-    </form.Subscribe>
-
-    <form.AppField name="publicity">
-      {(field) => (
-        <field.Select
-          label="Privacy"
-          values={[
-            { label: 'Public', value: GoalPublicityType.Public },
-            { label: 'Private', value: GoalPublicityType.Private },
-          ]}
-          placeholder="Select a publicity type"
-        />
-      )}
-    </form.AppField>
-
-    {/* Color selection */}
-    <form.AppField name="colour">
-      {(field) => <field.ColourSelect label="Colour" />}
-    </form.AppField>
-
-    {/* Icon selection */}
-    <form.AppField name="icon">
-      {(field) => <field.IconSelect label="Icon" />}
-    </form.AppField>
-
-    <div className="flex flex-row gap-1.5 justify-end">
-      <form.AppForm>
-        {!isCreate && (
-          <DeleteDialog
-            title="Delete Goal"
-            description="Deleting a goal is permanent. This will also delete any associated entries. Are you sure you want to delete this goal?"
-            onDelete={handleDelete}
-          >
-            <Button type="button" variant={'ghostDestructive'}>
-              Delete
-            </Button>
-          </DeleteDialog>
+      <form.AppField name="description">
+        {(field) => (
+          <field.TextField
+            label="Description"
+            placeholder="Optional. Add more details if needed"
+          />
         )}
-        <form.SubscribeButton label={isCreate ? 'Create' : 'Save'} />
-      </form.AppForm>
-    </div>
-  </form>
+      </form.AppField>
+
+      {/* Goal type. Note: hiding when editing goal, as cannot convert goal entries between the two types */}
+      {isCreate && (
+        <form.AppField name="goalType">
+          {(field) => (
+            <field.RadioGroup
+              label="Goal Type"
+              values={[
+                { label: 'Numeric', value: GoalQuantifyType.Numeric },
+                { label: 'Boolean', value: GoalQuantifyType.Boolean },
+              ]}
+            />
+          )}
+        </form.AppField>
+      )}
+
+      <form.Subscribe selector={(state) => state.values.goalType}>
+        {(goalType) => {
+          if (goalType === GoalQuantifyType.Numeric) {
+            return (
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <form.AppField name="numericTarget">
+                  {(field) => (
+                    <field.NumberField
+                      label="Daily Target"
+                      placeholder="e.g. 30"
+                    />
+                  )}
+                </form.AppField>
+                <form.AppField name="numericUnit">
+                  {(field) => (
+                    <field.TextField
+                      label="Units"
+                      placeholder="e.g. km, hours, sessions"
+                    />
+                  )}
+                </form.AppField>
+              </div>
+            )
+          } else {
+            return null
+          }
+        }}
+      </form.Subscribe>
+
+      <form.AppField name="publicity">
+        {(field) => (
+          <field.Select
+            label="Privacy"
+            values={[
+              { label: 'Public', value: GoalPublicityType.Public },
+              { label: 'Private', value: GoalPublicityType.Private },
+            ]}
+            placeholder="Select a publicity type"
+          />
+        )}
+      </form.AppField>
+
+      {/* Color selection */}
+      <form.AppField name="colour">
+        {(field) => <field.ColourSelect label="Colour" />}
+      </form.AppField>
+
+      {/* Icon selection */}
+      <form.AppField name="icon">
+        {(field) => <field.IconSelect label="Icon" />}
+      </form.AppField>
+
+      <div className="flex flex-row gap-1.5 justify-end">
+        <form.AppForm>
+          {!isCreate && (
+            <DeleteDialog
+              title="Delete Goal"
+              description="Deleting a goal is permanent. This will also delete any associated entries. Are you sure you want to delete this goal?"
+              onDelete={handleDelete}
+            >
+              <Button type="button" variant={'ghostDestructive'}>
+                Delete
+              </Button>
+            </DeleteDialog>
+          )}
+          <form.SubscribeButton label={isCreate ? 'Create' : 'Save'} />
+        </form.AppForm>
+      </div>
+    </form>
   )
 }
 
@@ -270,30 +266,35 @@ export const SkeletonGoalForm: React.FC = () => {
   )
 }
 
-
 /**
  * Public components
  */
 
 export function SkeletonGoalCreatePage() {
-  return <GoalPage>
-    <GoalHeader isCreate={true} />
-    <SkeletonGoalForm />
-  </GoalPage>
+  return (
+    <GoalPage>
+      <GoalHeader isCreate={true} />
+      <SkeletonGoalForm />
+    </GoalPage>
+  )
 }
 
 export function SkeletonGoalEditPage() {
-  return <GoalPage>
-    <GoalHeader isCreate={false} />
-    <SkeletonGoalForm />
-  </GoalPage>
+  return (
+    <GoalPage>
+      <GoalHeader isCreate={false} />
+      <SkeletonGoalForm />
+    </GoalPage>
+  )
 }
 
 export function GoalCreatePage() {
-  return <GoalPage>
-    <GoalHeader isCreate={true} />
-    <GoalForm isCreate={true}/>
-  </GoalPage>
+  return (
+    <GoalPage>
+      <GoalHeader isCreate={true} />
+      <GoalForm isCreate={true} />
+    </GoalPage>
+  )
 }
 
 export function GoalEditPage() {
@@ -305,9 +306,7 @@ export function GoalEditPage() {
   return (
     <GoalPage>
       <GoalHeader isCreate={false} />
-      {isLoading && 
-        <SkeletonGoalForm />
-      }
+      {isLoading && <SkeletonGoalForm />}
       {error && (
         <ErrorBodyComponent
           error={error}

--- a/apps/client/src/features/goals/GoalCreatePage.tsx
+++ b/apps/client/src/features/goals/GoalCreatePage.tsx
@@ -1,9 +1,7 @@
-import React, { useState } from 'react'
+import React from 'react'
 import {
   getRouteApi,
-  useCanGoBack,
   useNavigate,
-  useRouter,
 } from '@tanstack/react-router'
 import {
   CreateGoalSchema,

--- a/apps/client/src/features/goals/GoalDetailsPage.tsx
+++ b/apps/client/src/features/goals/GoalDetailsPage.tsx
@@ -17,6 +17,7 @@ import IconButton from '@/components/custom/IconButton'
 import { TopBarBack } from '@/components/custom/TopBar'
 import { ErrorBodyComponent } from '@/components/custom/ErrorComponents'
 import { useCurrentDate } from '@/hooks/useCurrentDate'
+import { Skeleton } from '@/components/ui/skeleton'
 
 
 /**
@@ -47,7 +48,14 @@ const GoalPanel: React.FC<GoalPanelProps> = ({
   } = useGoal(goalId);
 
   return <>
-    {goalIsLoading && <div>Goal Loading...</div>}
+    {/* Goal data skeleton */}
+    {goalIsLoading && <>
+      {/* Goal description */}
+      <Skeleton className="h-[60px] w-full" />
+      {/* Heatmap container */}
+      <Skeleton className="h-[240px] w-full" />
+    </>}
+    {/* Goal data error */}
     {goalError && (
       <ErrorBodyComponent
         error={goalError}
@@ -59,6 +67,7 @@ const GoalPanel: React.FC<GoalPanelProps> = ({
         }}
       />
     )}
+    {/* Goal data content */}
     {goalData && <>
       {/* Goal description */}
       <div className="header-container flex flex-row justify-between items-center bg-white rounded-xl p-2.5 shadow-sm">
@@ -110,8 +119,10 @@ const GoalStats: React.FC<GoalStatsProps> = ({
   goalId,
   selectedYear,
 }) => {
+  const navigate = useNavigate()
   const {
-    data: goalData
+    data: goalData,
+    isLoading: goalIsLoading
   } = useGoal(goalId)
 
   const {
@@ -158,8 +169,27 @@ const GoalStats: React.FC<GoalStatsProps> = ({
 
   return <>
     {/* Gridded summary statistics */}
-    {(goalData && statsData) && (
-      <div className="grid grid-cols-2 grid-rows-2 gap-3">
+    <div className="grid grid-cols-2 grid-rows-2 gap-3">
+      {/* Stats loading */}
+      {(goalIsLoading || statsIsLoading) && <>
+        {Object.entries(GOAL_STATS_DISPLAYS).map(() => {
+          return <Skeleton className="h-[100px] w-full" />
+        })}
+      </>}
+      {/* Stats error */}
+      {statsError && (
+        <ErrorBodyComponent
+          error={statsError}
+          onRefreshClick={() => {
+            console.log('Have refresh do something')
+          }}
+          onBackClick={() => {
+            navigate({ to: '/goals' })
+          }}
+        />
+      )}
+      {/* Stats content */}
+      {(goalData && statsData) && <>
         {Object.entries(statsData).map(([key, value]) => {
           const display = GOAL_STATS_DISPLAYS[key as GoalStatsKeys]
           return (
@@ -201,8 +231,8 @@ const GoalStats: React.FC<GoalStatsProps> = ({
             </div>
           )
         })}
-      </div>
-    )}
+      </>}
+    </div>
   </>
 }
 
@@ -219,8 +249,10 @@ const GoalMonthlyAveragesChart: React.FC<GoalMonthlyAveragesChartProps> = ({
   goalId,
   selectedYear,
 }) => {
+  const navigate = useNavigate()
   const {
-    data: goalData
+    data: goalData,
+    isLoading: goalIsLoading,
   } = useGoal(goalId)
 
   const {
@@ -234,6 +266,21 @@ const GoalMonthlyAveragesChart: React.FC<GoalMonthlyAveragesChartProps> = ({
   
   return <>
     {/* Line graph: monthly averages */}
+    {/* Averages loading */}
+    {(goalIsLoading || monthlyAvgsIsLoading) && <Skeleton className="h-[300px] w-full" />}
+    {/* Averages error */}
+    {monthlyAvgsError && (
+      <ErrorBodyComponent
+        error={monthlyAvgsError}
+        onRefreshClick={() => {
+          console.log('Have refresh do something')
+        }}
+        onBackClick={() => {
+          navigate({ to: '/goals' })
+        }}
+      />
+    )}
+    {/* Averages data */}
     {(goalData && monthlyAvgsData) && (
       <MonthAreaChart
         baseColour={goalData.colour}
@@ -252,7 +299,7 @@ const GoalMonthlyAveragesChart: React.FC<GoalMonthlyAveragesChartProps> = ({
 
 /**
  * Goal Monthly Counts Chart:
- * Displays line chart with x-axis being month, y-axis being goal average value for that month
+ * Displays line chart with x-axis being month, y-axis being goal count value for that month
  */
 interface GoalMonthlyCountsChartProps {
   goalId: string,
@@ -263,8 +310,10 @@ const GoalMonthlyCountsChart: React.FC<GoalMonthlyCountsChartProps> = ({
   goalId,
   selectedYear,
 }) => {
+  const navigate = useNavigate()
   const {
-    data: goalData
+    data: goalData,
+    isLoading: goalIsLoading,
   } = useGoal(goalId)
 
   const {
@@ -278,6 +327,21 @@ const GoalMonthlyCountsChart: React.FC<GoalMonthlyCountsChartProps> = ({
   
   return <>
     {/* Line graph: monthly counts */}
+    {/* Counts loading */}
+    {(goalIsLoading || monthlyCountsIsLoading) && <Skeleton className="h-[300px] w-full" />}
+    {/* Counts error */}
+    {monthlyCountsError && (
+      <ErrorBodyComponent
+        error={monthlyCountsError}
+        onRefreshClick={() => {
+          console.log('Have refresh do something')
+        }}
+        onBackClick={() => {
+          navigate({ to: '/goals' })
+        }}
+      />
+    )}
+    {/* Counts data */}
     {(goalData && monthlyCountsData) && (
       <MonthAreaChart
         baseColour={goalData.colour}
@@ -302,7 +366,7 @@ export const GoalDetailsPage = () => {
   const navigate = useNavigate()
   const route = getRouteApi('/goals_/$goalId')
 
-  // TODOs #12 Improve loading display + error display
+  // TODOs #12 Improve error display
   const currentYear = useCurrentDate().getFullYear()
   const { goalId } = route.useParams()
   const [selectedYear, setSelectedYear] = useState<number>(currentYear)

--- a/apps/client/src/features/goals/GoalDetailsPage.tsx
+++ b/apps/client/src/features/goals/GoalDetailsPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, type Dispatch } from 'react'
 import { DynamicIcon } from 'lucide-react/dynamic'
 import { getRouteApi, useNavigate } from '@tanstack/react-router'
 import { GoalQuantifyType } from '@habit-tracker/validation-schemas'
@@ -18,44 +18,107 @@ import { TopBarBack } from '@/components/custom/TopBar'
 import { ErrorBodyComponent } from '@/components/custom/ErrorComponents'
 import { useCurrentDate } from '@/hooks/useCurrentDate'
 
-export const GoalDetailsPage = () => {
+
+/**
+ * Private components
+ */
+
+
+/**
+ * Goal Panel:
+ * Contains goal description/ info card + heatmap card
+ */
+interface GoalPanelProps {
+  goalId: string,
+  selectedYear: number,
+  setSelectedYear: Dispatch<number>
+}
+
+const GoalPanel: React.FC<GoalPanelProps> = ({
+  goalId,
+  selectedYear,
+  setSelectedYear,
+}) => {
   const navigate = useNavigate()
-  const route = getRouteApi('/goals_/$goalId')
-
-  // TODOs #12 Improve loading display + error display
-  const currentYear = useCurrentDate().getFullYear()
-  const { goalId } = route.useParams()
-  const [selectedYear, setSelectedYear] = useState<number>(currentYear)
-
-  // Un-used variables to be addressed in #12
-  /* eslint-disable @typescript-eslint/no-unused-vars */
   const {
     data: goalData,
     isLoading: goalIsLoading,
     error: goalError,
+  } = useGoal(goalId);
+
+  return <>
+    {goalIsLoading && <div>Goal Loading...</div>}
+    {goalError && (
+      <ErrorBodyComponent
+        error={goalError}
+        onRefreshClick={() => {
+          console.log('Have refresh do something')
+        }}
+        onBackClick={() => {
+          navigate({ to: '/goals' })
+        }}
+      />
+    )}
+    {goalData && <>
+      {/* Goal description */}
+      <div className="header-container flex flex-row justify-between items-center bg-white rounded-xl p-2.5 shadow-sm">
+        <GoalIconText
+          title={goalData.title}
+          description={goalData.description}
+          baseColour={goalData.colour}
+          iconName={goalData.icon as IconName}
+        />
+        <div className="buttons-container flex flex-row gap-1">
+          <IconButton
+            iconName="pencil"
+            tooltip="Edit Goal"
+            onClickCallback={() => {
+              navigate({
+                to: '/goals/$goalId/edit',
+                params: { goalId: goalData.id.toString() },
+              })
+            }}
+          />
+        </div>
+      </div>
+
+      {/* Heatmap container */}
+      <GoalCardControlled
+        goalData={goalData}
+        selectedYear={selectedYear}
+        onCalendarSelect={(year) => {
+          console.log('Goal details page > calendar selection made', year)
+          setSelectedYear(year)
+        }}
+        viewOnly={false}
+      />
+    </>
+    }
+  </>
+}
+
+/**
+ * Goal Stats:
+ * Contains stat cards for e.g. daily average, days tracked, etc
+ */
+interface GoalStatsProps {
+  goalId: string,
+  selectedYear: number,
+}
+
+const GoalStats: React.FC<GoalStatsProps> = ({
+  goalId,
+  selectedYear,
+}) => {
+  const {
+    data: goalData
   } = useGoal(goalId)
+
   const {
     data: statsData,
     isLoading: statsIsLoading,
     error: statsError,
   } = useGoalStatistics({ goalId: parseInt(goalId), year: selectedYear })
-  const {
-    data: monthlyAvgsData,
-    isLoading: monthlyAvgsIsLoading,
-    error: monthlyAvgsError,
-  } = useGoalMonthlyAvgs(
-    { goalId: parseInt(goalId), year: selectedYear },
-    goalData?.goalType === GoalQuantifyType.Numeric,
-  )
-  const {
-    data: monthlyCountsData,
-    isLoading: monthlyCountsIsLoading,
-    error: monthlyCountsError,
-  } = useGoalMonthlyCounts(
-    { goalId: parseInt(goalId), year: selectedYear },
-    goalData?.goalType === GoalQuantifyType.Boolean,
-  )
-  /* eslint-enable @typescript-eslint/no-unused-vars */
 
   type GoalStatsKeys = keyof GoalStatisticsReponse
   interface GoalStatsDisplay {
@@ -93,6 +156,157 @@ export const GoalDetailsPage = () => {
     }
   }
 
+  return <>
+    {/* Gridded summary statistics */}
+    {(goalData && statsData) && (
+      <div className="grid grid-cols-2 grid-rows-2 gap-3">
+        {Object.entries(statsData).map(([key, value]) => {
+          const display = GOAL_STATS_DISPLAYS[key as GoalStatsKeys]
+          return (
+            <div
+              key={`statsCard_${key}`}
+              className="bg-white rounded-xl p-2.5 shadow-sm"
+            >
+              <div className="flex flex-row gap-3">
+                <h3 className="w-full text-base font-semibold">
+                  {display.title}
+                </h3>
+                <div
+                  className="icon-container w-9 h-9 flex items-center justify-center rounded-md"
+                  style={{
+                    backgroundColor:
+                      // TODOs #18: light/ dark mode differing opacities. :dark selector?
+                      `#${goalData.colour}1A`, // /< 66 - 40% for dark mode, 1A - 10% for light mode
+                    color: `#${goalData.colour}`,
+                    strokeOpacity: 0.8, // /< 1.0 for dark mode, 0.8 for light mode
+                  }}
+                >
+                  <DynamicIcon name={display.icon} />
+                </div>
+              </div>
+              {display.labelOverride ? (
+                <span className="text-3xl font-semibold">
+                  {display.labelOverride}
+                </span>
+              ) : (
+                <>
+                  <span className="text-4xl font-semibold">
+                    {roundIfDecimal(value || 0)}
+                  </span>{' '}
+                  <span className="text-xl font-medium">
+                    {display.units}
+                  </span>
+                </>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    )}
+  </>
+}
+
+/**
+ * Goal Monthly Averages Chart:
+ * Displays line chart with x-axis being month, y-axis being goal average value for that month
+ */
+interface GoalMonthlyAveragesChartProps {
+  goalId: string,
+  selectedYear: number,
+}
+
+const GoalMonthlyAveragesChart: React.FC<GoalMonthlyAveragesChartProps> = ({
+  goalId,
+  selectedYear,
+}) => {
+  const {
+    data: goalData
+  } = useGoal(goalId)
+
+  const {
+    data: monthlyAvgsData,
+    isLoading: monthlyAvgsIsLoading,
+    error: monthlyAvgsError,
+  } = useGoalMonthlyAvgs(
+    { goalId: parseInt(goalId), year: selectedYear },
+    goalData?.goalType === GoalQuantifyType.Numeric,
+  )
+  
+  return <>
+    {/* Line graph: monthly averages */}
+    {(goalData && monthlyAvgsData) && (
+      <MonthAreaChart
+        baseColour={goalData.colour}
+        valueLabel="Average"
+        inputChartData={monthlyAvgsData.map((item) => {
+          return {
+            year: item.year,
+            month: item.month,
+            value: item.average,
+          }
+        })}
+      />
+    )}
+  </>
+}
+
+/**
+ * Goal Monthly Counts Chart:
+ * Displays line chart with x-axis being month, y-axis being goal average value for that month
+ */
+interface GoalMonthlyCountsChartProps {
+  goalId: string,
+  selectedYear: number,
+}
+
+const GoalMonthlyCountsChart: React.FC<GoalMonthlyCountsChartProps> = ({
+  goalId,
+  selectedYear,
+}) => {
+  const {
+    data: goalData
+  } = useGoal(goalId)
+
+  const {
+    data: monthlyCountsData,
+    isLoading: monthlyCountsIsLoading,
+    error: monthlyCountsError,
+  } = useGoalMonthlyCounts(
+    { goalId: parseInt(goalId), year: selectedYear },
+    goalData?.goalType === GoalQuantifyType.Boolean,
+  )
+  
+  return <>
+    {/* Line graph: monthly counts */}
+    {(goalData && monthlyCountsData) && (
+      <MonthAreaChart
+        baseColour={goalData.colour}
+        valueLabel="Completions"
+        inputChartData={monthlyCountsData.map((item) => {
+          return {
+            year: item.year,
+            month: item.month,
+            value: item.count,
+          }
+        })}
+      />
+    )}
+  </>
+}
+
+/**
+ * Public components
+ */
+
+export const GoalDetailsPage = () => {
+  const navigate = useNavigate()
+  const route = getRouteApi('/goals_/$goalId')
+
+  // TODOs #12 Improve loading display + error display
+  const currentYear = useCurrentDate().getFullYear()
+  const { goalId } = route.useParams()
+  const [selectedYear, setSelectedYear] = useState<number>(currentYear)
+  
   return (
     <div className="flex flex-col gap-3">
       {/* Topbar config */}
@@ -102,130 +316,11 @@ export const GoalDetailsPage = () => {
           navigate({ to: '/goals' })
         }}
       />
-      {goalIsLoading && <div>Goal Loading...</div>}
-      {goalError && (
-        <ErrorBodyComponent
-          error={goalError}
-          onRefreshClick={() => {
-            console.log('Have refresh do something')
-          }}
-          onBackClick={() => {
-            navigate({ to: '/goals' })
-          }}
-        />
-      )}
-      {goalData && (
-        <>
-          {/* Goal description container */}
-          <div className="header-container flex flex-row justify-between items-center bg-white rounded-xl p-2.5 shadow-sm">
-            <GoalIconText
-              title={goalData.title}
-              description={goalData.description}
-              baseColour={goalData.colour}
-              iconName={goalData.icon as IconName}
-            />
-            <div className="buttons-container flex flex-row gap-1">
-              <IconButton
-                iconName="pencil"
-                tooltip="Edit Goal"
-                onClickCallback={() => {
-                  navigate({
-                    to: '/goals/$goalId/edit',
-                    params: { goalId: goalData.id.toString() },
-                  })
-                }}
-              />
-            </div>
-          </div>
-
-          {/* Heatmap container */}
-          <GoalCardControlled
-            goalData={goalData}
-            selectedYear={selectedYear}
-            onCalendarSelect={(year) => {
-              console.log('Goal details page > calendar selection made', year)
-              setSelectedYear(year)
-            }}
-          />
-
-          {/* Gridded summary statistics */}
-          {statsData && (
-            <div className="grid grid-cols-2 grid-rows-2 gap-3">
-              {Object.entries(statsData).map(([key, value]) => {
-                const display = GOAL_STATS_DISPLAYS[key as GoalStatsKeys]
-                return (
-                  <div
-                    key={`statsCard_${key}`}
-                    className="bg-white rounded-xl p-2.5 shadow-sm"
-                  >
-                    <div className="flex flex-row gap-3">
-                      <h3 className="w-full text-base font-semibold">
-                        {display.title}
-                      </h3>
-                      <div
-                        className="icon-container w-9 h-9 flex items-center justify-center rounded-md"
-                        style={{
-                          backgroundColor:
-                            // TODOs #18: light/ dark mode differing opacities. :dark selector?
-                            `#${goalData.colour}1A`, // /< 66 - 40% for dark mode, 1A - 10% for light mode
-                          color: `#${goalData.colour}`,
-                          strokeOpacity: 0.8, // /< 1.0 for dark mode, 0.8 for light mode
-                        }}
-                      >
-                        <DynamicIcon name={display.icon} />
-                      </div>
-                    </div>
-                    {display.labelOverride ? (
-                      <span className="text-3xl font-semibold">
-                        {display.labelOverride}
-                      </span>
-                    ) : (
-                      <>
-                        <span className="text-4xl font-semibold">
-                          {roundIfDecimal(value || 0)}
-                        </span>{' '}
-                        <span className="text-xl font-medium">
-                          {display.units}
-                        </span>
-                      </>
-                    )}
-                  </div>
-                )
-              })}
-            </div>
-          )}
-
-          {/* Line graph: monthly averages */}
-          {monthlyAvgsData && (
-            <MonthAreaChart
-              baseColour={goalData.colour}
-              valueLabel="Average"
-              inputChartData={monthlyAvgsData.map((item) => {
-                return {
-                  year: item.year,
-                  month: item.month,
-                  value: item.average,
-                }
-              })}
-            />
-          )}
-
-          {/* Line graph: monthly counts */}
-          {monthlyCountsData && (
-            <MonthAreaChart
-              baseColour={goalData.colour}
-              valueLabel="Completions"
-              inputChartData={monthlyCountsData.map((item) => {
-                return {
-                  year: item.year,
-                  month: item.month,
-                  value: item.count,
-                }
-              })}
-            />
-          )}
-        </>
-      )}
+      {/* Detail content components */}
+      <GoalPanel goalId={goalId} selectedYear={selectedYear} setSelectedYear={setSelectedYear} />
+      <GoalStats goalId={goalId} selectedYear={selectedYear} />
+      <GoalMonthlyAveragesChart goalId={goalId} selectedYear={selectedYear} />
+      <GoalMonthlyCountsChart goalId={goalId} selectedYear={selectedYear} />
     </div>
   )
 }

--- a/apps/client/src/features/goals/GoalDetailsPage.tsx
+++ b/apps/client/src/features/goals/GoalDetailsPage.tsx
@@ -15,9 +15,10 @@ import type { IconName } from 'lucide-react/dynamic'
 import type { GoalStatisticsReponse } from '@habit-tracker/validation-schemas'
 import IconButton from '@/components/custom/IconButton'
 import { TopBarBack } from '@/components/custom/TopBar'
-import { ErrorBodyComponent } from '@/components/custom/ErrorComponents'
+import { ErrorBodyComponent, ErrorBodyComponentPosition, ErrorBodyComponentSize } from '@/components/custom/ErrorComponents'
 import { useCurrentDate } from '@/hooks/useCurrentDate'
 import { Skeleton } from '@/components/ui/skeleton'
+import { Button } from '@/components/ui/button'
 
 
 /**
@@ -45,6 +46,7 @@ const GoalPanel: React.FC<GoalPanelProps> = ({
     data: goalData,
     isLoading: goalIsLoading,
     error: goalError,
+    refetch
   } = useGoal(goalId);
 
   return <>
@@ -60,7 +62,7 @@ const GoalPanel: React.FC<GoalPanelProps> = ({
       <ErrorBodyComponent
         error={goalError}
         onRefreshClick={() => {
-          console.log('Have refresh do something')
+          refetch()
         }}
         onBackClick={() => {
           navigate({ to: '/goals' })
@@ -129,7 +131,11 @@ const GoalStats: React.FC<GoalStatsProps> = ({
     data: statsData,
     isLoading: statsIsLoading,
     error: statsError,
-  } = useGoalStatistics({ goalId: parseInt(goalId), year: selectedYear })
+    refetch: statsRefetch,
+  } = useGoalStatistics(
+    { goalId: parseInt(goalId), year: selectedYear },
+    goalData !== undefined,
+  )
 
   type GoalStatsKeys = keyof GoalStatisticsReponse
   interface GoalStatsDisplay {
@@ -169,27 +175,23 @@ const GoalStats: React.FC<GoalStatsProps> = ({
 
   return <>
     {/* Gridded summary statistics */}
-    <div className="grid grid-cols-2 grid-rows-2 gap-3">
+    <>
       {/* Stats loading */}
-      {(goalIsLoading || statsIsLoading) && <>
+      {(goalIsLoading || statsIsLoading) && <div className="grid grid-cols-2 grid-rows-2 gap-3">
         {Object.entries(GOAL_STATS_DISPLAYS).map(() => {
           return <Skeleton className="h-[100px] w-full" />
         })}
-      </>}
+      </div>}
       {/* Stats error */}
-      {statsError && (
-        <ErrorBodyComponent
-          error={statsError}
-          onRefreshClick={() => {
-            console.log('Have refresh do something')
-          }}
-          onBackClick={() => {
-            navigate({ to: '/goals' })
-          }}
-        />
-      )}
+      {statsError && 
+        <div
+          className="bg-white rounded-xl p-2.5 shadow-sm h-[200px] w-full justify-center items-center"
+        >
+          <ErrorBodyComponent error={statsError} size={ErrorBodyComponentSize.Small} position={ErrorBodyComponentPosition.Centered} onRefreshClick={() => statsRefetch()} />
+        </div>
+      }
       {/* Stats content */}
-      {(goalData && statsData) && <>
+      {(goalData && statsData) && <div className="grid grid-cols-2 grid-rows-2 gap-3">
         {Object.entries(statsData).map(([key, value]) => {
           const display = GOAL_STATS_DISPLAYS[key as GoalStatsKeys]
           return (
@@ -231,8 +233,8 @@ const GoalStats: React.FC<GoalStatsProps> = ({
             </div>
           )
         })}
-      </>}
-    </div>
+      </div>}
+    </>
   </>
 }
 
@@ -259,9 +261,10 @@ const GoalMonthlyAveragesChart: React.FC<GoalMonthlyAveragesChartProps> = ({
     data: monthlyAvgsData,
     isLoading: monthlyAvgsIsLoading,
     error: monthlyAvgsError,
+    refetch: monthlyAvgsRefetch,
   } = useGoalMonthlyAvgs(
     { goalId: parseInt(goalId), year: selectedYear },
-    goalData?.goalType === GoalQuantifyType.Numeric,
+    goalData !== undefined && goalData.goalType === GoalQuantifyType.Numeric,
   )
   
   return <>
@@ -269,17 +272,13 @@ const GoalMonthlyAveragesChart: React.FC<GoalMonthlyAveragesChartProps> = ({
     {/* Averages loading */}
     {(goalIsLoading || monthlyAvgsIsLoading) && <Skeleton className="h-[300px] w-full" />}
     {/* Averages error */}
-    {monthlyAvgsError && (
-      <ErrorBodyComponent
-        error={monthlyAvgsError}
-        onRefreshClick={() => {
-          console.log('Have refresh do something')
-        }}
-        onBackClick={() => {
-          navigate({ to: '/goals' })
-        }}
-      />
-    )}
+    {monthlyAvgsError && 
+      <div
+        className="bg-white rounded-xl p-2.5 shadow-sm h-[200px] w-full justify-center items-center"
+      >
+        <ErrorBodyComponent error={monthlyAvgsError} size={ErrorBodyComponentSize.Small} position={ErrorBodyComponentPosition.Centered} onRefreshClick={() => monthlyAvgsRefetch()} />
+      </div>
+    }
     {/* Averages data */}
     {(goalData && monthlyAvgsData) && (
       <MonthAreaChart
@@ -320,9 +319,10 @@ const GoalMonthlyCountsChart: React.FC<GoalMonthlyCountsChartProps> = ({
     data: monthlyCountsData,
     isLoading: monthlyCountsIsLoading,
     error: monthlyCountsError,
+    refetch: monthlyCountsRefetch
   } = useGoalMonthlyCounts(
     { goalId: parseInt(goalId), year: selectedYear },
-    goalData?.goalType === GoalQuantifyType.Boolean,
+    goalData !== undefined && goalData.goalType === GoalQuantifyType.Boolean,
   )
   
   return <>
@@ -330,17 +330,13 @@ const GoalMonthlyCountsChart: React.FC<GoalMonthlyCountsChartProps> = ({
     {/* Counts loading */}
     {(goalIsLoading || monthlyCountsIsLoading) && <Skeleton className="h-[300px] w-full" />}
     {/* Counts error */}
-    {monthlyCountsError && (
-      <ErrorBodyComponent
-        error={monthlyCountsError}
-        onRefreshClick={() => {
-          console.log('Have refresh do something')
-        }}
-        onBackClick={() => {
-          navigate({ to: '/goals' })
-        }}
-      />
-    )}
+    {monthlyCountsError && 
+      <div
+        className="bg-white rounded-xl p-2.5 shadow-sm h-[200px] w-full justify-center items-center"
+      >
+        <ErrorBodyComponent error={monthlyCountsError} size={ErrorBodyComponentSize.Small} position={ErrorBodyComponentPosition.Centered} onRefreshClick={() => monthlyCountsRefetch()} />
+      </div>
+    }
     {/* Counts data */}
     {(goalData && monthlyCountsData) && (
       <MonthAreaChart
@@ -367,6 +363,7 @@ export const GoalDetailsPage = () => {
   const route = getRouteApi('/goals_/$goalId')
 
   // TODOs #12 Improve error display
+  // Update text to be less generic than "Oops! Something went wrong"
   const currentYear = useCurrentDate().getFullYear()
   const { goalId } = route.useParams()
   const [selectedYear, setSelectedYear] = useState<number>(currentYear)

--- a/apps/client/src/features/goals/GoalDetailsPage.tsx
+++ b/apps/client/src/features/goals/GoalDetailsPage.tsx
@@ -362,8 +362,6 @@ export const GoalDetailsPage = () => {
   const navigate = useNavigate()
   const route = getRouteApi('/goals_/$goalId')
 
-  // TODOs #12 Improve error display
-  // Update text to be less generic than "Oops! Something went wrong"
   const currentYear = useCurrentDate().getFullYear()
   const { goalId } = route.useParams()
   const [selectedYear, setSelectedYear] = useState<number>(currentYear)

--- a/apps/client/src/features/goals/GoalDetailsPage.tsx
+++ b/apps/client/src/features/goals/GoalDetailsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, type Dispatch } from 'react'
+import {  useState } from 'react'
 import { DynamicIcon } from 'lucide-react/dynamic'
 import { getRouteApi, useNavigate } from '@tanstack/react-router'
 import { GoalQuantifyType } from '@habit-tracker/validation-schemas'
@@ -11,6 +11,7 @@ import {
 import { GoalCardControlled } from './components/GoalCard'
 import { GoalIconText } from './components/GoalIconText'
 import MonthAreaChart from './components/MonthAreaChart'
+import type {Dispatch} from 'react';
 import type { IconName } from 'lucide-react/dynamic'
 import type { GoalStatisticsReponse } from '@habit-tracker/validation-schemas'
 import IconButton from '@/components/custom/IconButton'
@@ -18,7 +19,6 @@ import { TopBarBack } from '@/components/custom/TopBar'
 import { ErrorBodyComponent, ErrorBodyComponentPosition, ErrorBodyComponentSize } from '@/components/custom/ErrorComponents'
 import { useCurrentDate } from '@/hooks/useCurrentDate'
 import { Skeleton } from '@/components/ui/skeleton'
-import { Button } from '@/components/ui/button'
 
 
 /**
@@ -121,7 +121,6 @@ const GoalStats: React.FC<GoalStatsProps> = ({
   goalId,
   selectedYear,
 }) => {
-  const navigate = useNavigate()
   const {
     data: goalData,
     isLoading: goalIsLoading
@@ -251,7 +250,6 @@ const GoalMonthlyAveragesChart: React.FC<GoalMonthlyAveragesChartProps> = ({
   goalId,
   selectedYear,
 }) => {
-  const navigate = useNavigate()
   const {
     data: goalData,
     isLoading: goalIsLoading,
@@ -309,7 +307,6 @@ const GoalMonthlyCountsChart: React.FC<GoalMonthlyCountsChartProps> = ({
   goalId,
   selectedYear,
 }) => {
-  const navigate = useNavigate()
   const {
     data: goalData,
     isLoading: goalIsLoading,

--- a/apps/client/src/features/goals/GoalDetailsPage.tsx
+++ b/apps/client/src/features/goals/GoalDetailsPage.tsx
@@ -1,4 +1,4 @@
-import {  useState } from 'react'
+import { useState } from 'react'
 import { DynamicIcon } from 'lucide-react/dynamic'
 import { getRouteApi, useNavigate } from '@tanstack/react-router'
 import { GoalQuantifyType } from '@habit-tracker/validation-schemas'
@@ -11,28 +11,30 @@ import {
 import { GoalCardControlled } from './components/GoalCard'
 import { GoalIconText } from './components/GoalIconText'
 import MonthAreaChart from './components/MonthAreaChart'
-import type {Dispatch} from 'react';
+import type { Dispatch } from 'react'
 import type { IconName } from 'lucide-react/dynamic'
 import type { GoalStatisticsReponse } from '@habit-tracker/validation-schemas'
 import IconButton from '@/components/custom/IconButton'
 import { TopBarBack } from '@/components/custom/TopBar'
-import { ErrorBodyComponent, ErrorBodyComponentPosition, ErrorBodyComponentSize } from '@/components/custom/ErrorComponents'
+import {
+  ErrorBodyComponent,
+  ErrorBodyComponentPosition,
+  ErrorBodyComponentSize,
+} from '@/components/custom/ErrorComponents'
 import { useCurrentDate } from '@/hooks/useCurrentDate'
 import { Skeleton } from '@/components/ui/skeleton'
-
 
 /**
  * Private components
  */
-
 
 /**
  * Goal Panel:
  * Contains goal description/ info card + heatmap card
  */
 interface GoalPanelProps {
-  goalId: string,
-  selectedYear: number,
+  goalId: string
+  selectedYear: number
   setSelectedYear: Dispatch<number>
 }
 
@@ -46,66 +48,71 @@ const GoalPanel: React.FC<GoalPanelProps> = ({
     data: goalData,
     isLoading: goalIsLoading,
     error: goalError,
-    refetch
-  } = useGoal(goalId);
+    refetch,
+  } = useGoal(goalId)
 
-  return <>
-    {/* Goal data skeleton */}
-    {goalIsLoading && <>
-      {/* Goal description */}
-      <Skeleton className="h-[60px] w-full" />
-      {/* Heatmap container */}
-      <Skeleton className="h-[240px] w-full" />
-    </>}
-    {/* Goal data error */}
-    {goalError && (
-      <ErrorBodyComponent
-        error={goalError}
-        onRefreshClick={() => {
-          refetch()
-        }}
-        onBackClick={() => {
-          navigate({ to: '/goals' })
-        }}
-      />
-    )}
-    {/* Goal data content */}
-    {goalData && <>
-      {/* Goal description */}
-      <div className="header-container flex flex-row justify-between items-center bg-white rounded-xl p-2.5 shadow-sm">
-        <GoalIconText
-          title={goalData.title}
-          description={goalData.description}
-          baseColour={goalData.colour}
-          iconName={goalData.icon as IconName}
+  return (
+    <>
+      {/* Goal data skeleton */}
+      {goalIsLoading && (
+        <>
+          {/* Goal description */}
+          <Skeleton className="h-[60px] w-full" />
+          {/* Heatmap container */}
+          <Skeleton className="h-[240px] w-full" />
+        </>
+      )}
+      {/* Goal data error */}
+      {goalError && (
+        <ErrorBodyComponent
+          error={goalError}
+          onRefreshClick={() => {
+            refetch()
+          }}
+          onBackClick={() => {
+            navigate({ to: '/goals' })
+          }}
         />
-        <div className="buttons-container flex flex-row gap-1">
-          <IconButton
-            iconName="pencil"
-            tooltip="Edit Goal"
-            onClickCallback={() => {
-              navigate({
-                to: '/goals/$goalId/edit',
-                params: { goalId: goalData.id.toString() },
-              })
-            }}
-          />
-        </div>
-      </div>
+      )}
+      {/* Goal data content */}
+      {goalData && (
+        <>
+          {/* Goal description */}
+          <div className="header-container flex flex-row justify-between items-center bg-white rounded-xl p-2.5 shadow-sm">
+            <GoalIconText
+              title={goalData.title}
+              description={goalData.description}
+              baseColour={goalData.colour}
+              iconName={goalData.icon as IconName}
+            />
+            <div className="buttons-container flex flex-row gap-1">
+              <IconButton
+                iconName="pencil"
+                tooltip="Edit Goal"
+                onClickCallback={() => {
+                  navigate({
+                    to: '/goals/$goalId/edit',
+                    params: { goalId: goalData.id.toString() },
+                  })
+                }}
+              />
+            </div>
+          </div>
 
-      {/* Heatmap container */}
-      <GoalCardControlled
-        goalData={goalData}
-        selectedYear={selectedYear}
-        onCalendarSelect={(year) => {
-          console.log('Goal details page > calendar selection made', year)
-          setSelectedYear(year)
-        }}
-        viewOnly={false}
-      />
+          {/* Heatmap container */}
+          <GoalCardControlled
+            goalData={goalData}
+            selectedYear={selectedYear}
+            onCalendarSelect={(year) => {
+              console.log('Goal details page > calendar selection made', year)
+              setSelectedYear(year)
+            }}
+            viewOnly={false}
+          />
+        </>
+      )}
     </>
-    }
-  </>
+  )
 }
 
 /**
@@ -113,18 +120,12 @@ const GoalPanel: React.FC<GoalPanelProps> = ({
  * Contains stat cards for e.g. daily average, days tracked, etc
  */
 interface GoalStatsProps {
-  goalId: string,
-  selectedYear: number,
+  goalId: string
+  selectedYear: number
 }
 
-const GoalStats: React.FC<GoalStatsProps> = ({
-  goalId,
-  selectedYear,
-}) => {
-  const {
-    data: goalData,
-    isLoading: goalIsLoading
-  } = useGoal(goalId)
+const GoalStats: React.FC<GoalStatsProps> = ({ goalId, selectedYear }) => {
+  const { data: goalData, isLoading: goalIsLoading } = useGoal(goalId)
 
   const {
     data: statsData,
@@ -172,69 +173,78 @@ const GoalStats: React.FC<GoalStatsProps> = ({
     }
   }
 
-  return <>
-    {/* Gridded summary statistics */}
+  return (
     <>
-      {/* Stats loading */}
-      {(goalIsLoading || statsIsLoading) && <div className="grid grid-cols-2 grid-rows-2 gap-3">
-        {Object.entries(GOAL_STATS_DISPLAYS).map(() => {
-          return <Skeleton className="h-[100px] w-full" />
-        })}
-      </div>}
-      {/* Stats error */}
-      {statsError && 
-        <div
-          className="bg-white rounded-xl p-2.5 shadow-sm h-[200px] w-full justify-center items-center"
-        >
-          <ErrorBodyComponent error={statsError} size={ErrorBodyComponentSize.Small} position={ErrorBodyComponentPosition.Centered} onRefreshClick={() => statsRefetch()} />
-        </div>
-      }
-      {/* Stats content */}
-      {(goalData && statsData) && <div className="grid grid-cols-2 grid-rows-2 gap-3">
-        {Object.entries(statsData).map(([key, value]) => {
-          const display = GOAL_STATS_DISPLAYS[key as GoalStatsKeys]
-          return (
-            <div
-              key={`statsCard_${key}`}
-              className="bg-white rounded-xl p-2.5 shadow-sm"
-            >
-              <div className="flex flex-row gap-3">
-                <h3 className="w-full text-base font-semibold">
-                  {display.title}
-                </h3>
+      {/* Gridded summary statistics */}
+      <>
+        {/* Stats loading */}
+        {(goalIsLoading || statsIsLoading) && (
+          <div className="grid grid-cols-2 grid-rows-2 gap-3">
+            {Object.entries(GOAL_STATS_DISPLAYS).map(() => {
+              return <Skeleton className="h-[100px] w-full" />
+            })}
+          </div>
+        )}
+        {/* Stats error */}
+        {statsError && (
+          <div className="bg-white rounded-xl p-2.5 shadow-sm h-[200px] w-full justify-center items-center">
+            <ErrorBodyComponent
+              error={statsError}
+              size={ErrorBodyComponentSize.Small}
+              position={ErrorBodyComponentPosition.Centered}
+              onRefreshClick={() => statsRefetch()}
+            />
+          </div>
+        )}
+        {/* Stats content */}
+        {goalData && statsData && (
+          <div className="grid grid-cols-2 grid-rows-2 gap-3">
+            {Object.entries(statsData).map(([key, value]) => {
+              const display = GOAL_STATS_DISPLAYS[key as GoalStatsKeys]
+              return (
                 <div
-                  className="icon-container w-9 h-9 flex items-center justify-center rounded-md"
-                  style={{
-                    backgroundColor:
-                      // TODOs #18: light/ dark mode differing opacities. :dark selector?
-                      `#${goalData.colour}1A`, // /< 66 - 40% for dark mode, 1A - 10% for light mode
-                    color: `#${goalData.colour}`,
-                    strokeOpacity: 0.8, // /< 1.0 for dark mode, 0.8 for light mode
-                  }}
+                  key={`statsCard_${key}`}
+                  className="bg-white rounded-xl p-2.5 shadow-sm"
                 >
-                  <DynamicIcon name={display.icon} />
+                  <div className="flex flex-row gap-3">
+                    <h3 className="w-full text-base font-semibold">
+                      {display.title}
+                    </h3>
+                    <div
+                      className="icon-container w-9 h-9 flex items-center justify-center rounded-md"
+                      style={{
+                        backgroundColor:
+                          // TODOs #18: light/ dark mode differing opacities. :dark selector?
+                          `#${goalData.colour}1A`, // /< 66 - 40% for dark mode, 1A - 10% for light mode
+                        color: `#${goalData.colour}`,
+                        strokeOpacity: 0.8, // /< 1.0 for dark mode, 0.8 for light mode
+                      }}
+                    >
+                      <DynamicIcon name={display.icon} />
+                    </div>
+                  </div>
+                  {display.labelOverride ? (
+                    <span className="text-3xl font-semibold">
+                      {display.labelOverride}
+                    </span>
+                  ) : (
+                    <>
+                      <span className="text-4xl font-semibold">
+                        {roundIfDecimal(value || 0)}
+                      </span>{' '}
+                      <span className="text-xl font-medium">
+                        {display.units}
+                      </span>
+                    </>
+                  )}
                 </div>
-              </div>
-              {display.labelOverride ? (
-                <span className="text-3xl font-semibold">
-                  {display.labelOverride}
-                </span>
-              ) : (
-                <>
-                  <span className="text-4xl font-semibold">
-                    {roundIfDecimal(value || 0)}
-                  </span>{' '}
-                  <span className="text-xl font-medium">
-                    {display.units}
-                  </span>
-                </>
-              )}
-            </div>
-          )
-        })}
-      </div>}
+              )
+            })}
+          </div>
+        )}
+      </>
     </>
-  </>
+  )
 }
 
 /**
@@ -242,18 +252,15 @@ const GoalStats: React.FC<GoalStatsProps> = ({
  * Displays line chart with x-axis being month, y-axis being goal average value for that month
  */
 interface GoalMonthlyAveragesChartProps {
-  goalId: string,
-  selectedYear: number,
+  goalId: string
+  selectedYear: number
 }
 
 const GoalMonthlyAveragesChart: React.FC<GoalMonthlyAveragesChartProps> = ({
   goalId,
   selectedYear,
 }) => {
-  const {
-    data: goalData,
-    isLoading: goalIsLoading,
-  } = useGoal(goalId)
+  const { data: goalData, isLoading: goalIsLoading } = useGoal(goalId)
 
   const {
     data: monthlyAvgsData,
@@ -264,34 +271,41 @@ const GoalMonthlyAveragesChart: React.FC<GoalMonthlyAveragesChartProps> = ({
     { goalId: parseInt(goalId), year: selectedYear },
     goalData !== undefined && goalData.goalType === GoalQuantifyType.Numeric,
   )
-  
-  return <>
-    {/* Line graph: monthly averages */}
-    {/* Averages loading */}
-    {(goalIsLoading || monthlyAvgsIsLoading) && <Skeleton className="h-[300px] w-full" />}
-    {/* Averages error */}
-    {monthlyAvgsError && 
-      <div
-        className="bg-white rounded-xl p-2.5 shadow-sm h-[200px] w-full justify-center items-center"
-      >
-        <ErrorBodyComponent error={monthlyAvgsError} size={ErrorBodyComponentSize.Small} position={ErrorBodyComponentPosition.Centered} onRefreshClick={() => monthlyAvgsRefetch()} />
-      </div>
-    }
-    {/* Averages data */}
-    {(goalData && monthlyAvgsData) && (
-      <MonthAreaChart
-        baseColour={goalData.colour}
-        valueLabel="Average"
-        inputChartData={monthlyAvgsData.map((item) => {
-          return {
-            year: item.year,
-            month: item.month,
-            value: item.average,
-          }
-        })}
-      />
-    )}
-  </>
+
+  return (
+    <>
+      {/* Line graph: monthly averages */}
+      {/* Averages loading */}
+      {(goalIsLoading || monthlyAvgsIsLoading) && (
+        <Skeleton className="h-[300px] w-full" />
+      )}
+      {/* Averages error */}
+      {monthlyAvgsError && (
+        <div className="bg-white rounded-xl p-2.5 shadow-sm h-[200px] w-full justify-center items-center">
+          <ErrorBodyComponent
+            error={monthlyAvgsError}
+            size={ErrorBodyComponentSize.Small}
+            position={ErrorBodyComponentPosition.Centered}
+            onRefreshClick={() => monthlyAvgsRefetch()}
+          />
+        </div>
+      )}
+      {/* Averages data */}
+      {goalData && monthlyAvgsData && (
+        <MonthAreaChart
+          baseColour={goalData.colour}
+          valueLabel="Average"
+          inputChartData={monthlyAvgsData.map((item) => {
+            return {
+              year: item.year,
+              month: item.month,
+              value: item.average,
+            }
+          })}
+        />
+      )}
+    </>
+  )
 }
 
 /**
@@ -299,56 +313,60 @@ const GoalMonthlyAveragesChart: React.FC<GoalMonthlyAveragesChartProps> = ({
  * Displays line chart with x-axis being month, y-axis being goal count value for that month
  */
 interface GoalMonthlyCountsChartProps {
-  goalId: string,
-  selectedYear: number,
+  goalId: string
+  selectedYear: number
 }
 
 const GoalMonthlyCountsChart: React.FC<GoalMonthlyCountsChartProps> = ({
   goalId,
   selectedYear,
 }) => {
-  const {
-    data: goalData,
-    isLoading: goalIsLoading,
-  } = useGoal(goalId)
+  const { data: goalData, isLoading: goalIsLoading } = useGoal(goalId)
 
   const {
     data: monthlyCountsData,
     isLoading: monthlyCountsIsLoading,
     error: monthlyCountsError,
-    refetch: monthlyCountsRefetch
+    refetch: monthlyCountsRefetch,
   } = useGoalMonthlyCounts(
     { goalId: parseInt(goalId), year: selectedYear },
     goalData !== undefined && goalData.goalType === GoalQuantifyType.Boolean,
   )
-  
-  return <>
-    {/* Line graph: monthly counts */}
-    {/* Counts loading */}
-    {(goalIsLoading || monthlyCountsIsLoading) && <Skeleton className="h-[300px] w-full" />}
-    {/* Counts error */}
-    {monthlyCountsError && 
-      <div
-        className="bg-white rounded-xl p-2.5 shadow-sm h-[200px] w-full justify-center items-center"
-      >
-        <ErrorBodyComponent error={monthlyCountsError} size={ErrorBodyComponentSize.Small} position={ErrorBodyComponentPosition.Centered} onRefreshClick={() => monthlyCountsRefetch()} />
-      </div>
-    }
-    {/* Counts data */}
-    {(goalData && monthlyCountsData) && (
-      <MonthAreaChart
-        baseColour={goalData.colour}
-        valueLabel="Completions"
-        inputChartData={monthlyCountsData.map((item) => {
-          return {
-            year: item.year,
-            month: item.month,
-            value: item.count,
-          }
-        })}
-      />
-    )}
-  </>
+
+  return (
+    <>
+      {/* Line graph: monthly counts */}
+      {/* Counts loading */}
+      {(goalIsLoading || monthlyCountsIsLoading) && (
+        <Skeleton className="h-[300px] w-full" />
+      )}
+      {/* Counts error */}
+      {monthlyCountsError && (
+        <div className="bg-white rounded-xl p-2.5 shadow-sm h-[200px] w-full justify-center items-center">
+          <ErrorBodyComponent
+            error={monthlyCountsError}
+            size={ErrorBodyComponentSize.Small}
+            position={ErrorBodyComponentPosition.Centered}
+            onRefreshClick={() => monthlyCountsRefetch()}
+          />
+        </div>
+      )}
+      {/* Counts data */}
+      {goalData && monthlyCountsData && (
+        <MonthAreaChart
+          baseColour={goalData.colour}
+          valueLabel="Completions"
+          inputChartData={monthlyCountsData.map((item) => {
+            return {
+              year: item.year,
+              month: item.month,
+              value: item.count,
+            }
+          })}
+        />
+      )}
+    </>
+  )
 }
 
 /**
@@ -362,7 +380,7 @@ export const GoalDetailsPage = () => {
   const currentYear = useCurrentDate().getFullYear()
   const { goalId } = route.useParams()
   const [selectedYear, setSelectedYear] = useState<number>(currentYear)
-  
+
   return (
     <div className="flex flex-col gap-3">
       {/* Topbar config */}
@@ -373,7 +391,11 @@ export const GoalDetailsPage = () => {
         }}
       />
       {/* Detail content components */}
-      <GoalPanel goalId={goalId} selectedYear={selectedYear} setSelectedYear={setSelectedYear} />
+      <GoalPanel
+        goalId={goalId}
+        selectedYear={selectedYear}
+        setSelectedYear={setSelectedYear}
+      />
       <GoalStats goalId={goalId} selectedYear={selectedYear} />
       <GoalMonthlyAveragesChart goalId={goalId} selectedYear={selectedYear} />
       <GoalMonthlyCountsChart goalId={goalId} selectedYear={selectedYear} />

--- a/apps/client/src/features/goals/GoalsPage.tsx
+++ b/apps/client/src/features/goals/GoalsPage.tsx
@@ -1,6 +1,5 @@
 import { useNavigate } from '@tanstack/react-router'
 import { useState } from 'react'
-import { HTTPError } from 'ky'
 import { useGoals } from '../../apis/GoalApi'
 import { GoalCardDescriptive, SkeletonGoalCard } from './components/GoalCard'
 import { YearDropdown } from './components/YearDropdown'

--- a/apps/client/src/features/goals/GoalsPage.tsx
+++ b/apps/client/src/features/goals/GoalsPage.tsx
@@ -28,9 +28,7 @@ export const GoalsPage = () => {
     .sort((a, b) => a.order - b.order)
   // TODOs #16: handle filtering on backend? how to fit with infinite scroll vs. pagination?
 
-  // Un-used variables to be addressed in #12
-  /* eslint-disable @typescript-eslint/no-unused-vars */
-  const { data: userData, isLoading: userLoading, error: userError } = useUser()
+  const { data: userData } = useUser()
   const username = userData?.username || 'Unknown'
   const usernameInitials = getInitials(username)
 

--- a/apps/client/src/features/goals/GoalsPage.tsx
+++ b/apps/client/src/features/goals/GoalsPage.tsx
@@ -53,13 +53,8 @@ export const GoalsPage = () => {
         console.log('Log out requested')
         logoutUserMutateFn(undefined, {
           onSuccess: () => navigate({ to: '/' }),
-          onError: (err: Error) => {
-            if (err instanceof HTTPError) {
-              // Open generic error component
-              // TODOs #12 Improve loading display + error display
-              console.log('Error on logout')
-            }
-          },
+          // Note: generic error snackbar/ toast will appear,
+          // hence deliberately not using onError
         })
       },
     },

--- a/apps/client/src/features/profile/ProfilePage.tsx
+++ b/apps/client/src/features/profile/ProfilePage.tsx
@@ -14,7 +14,11 @@ import { TopBarConfig } from '@/components/custom/TopBar'
 import { useCurrentYear } from '@/hooks/useCurrentDate'
 import { getInitials } from '@/lib/stringUtils'
 import { Skeleton } from '@/components/ui/skeleton'
-import { ErrorBodyComponent, ErrorBodyComponentPosition, ErrorBodyComponentSize } from '@/components/custom/ErrorComponents'
+import {
+  ErrorBodyComponent,
+  ErrorBodyComponentPosition,
+  ErrorBodyComponentSize,
+} from '@/components/custom/ErrorComponents'
 
 export const ProfilePage = () => {
   const navigate = useNavigate()
@@ -72,14 +76,15 @@ export const ProfilePage = () => {
       />
 
       {/* Profile data */}
-      {profileIsLoading && (
-        <Skeleton className="h-25 w-full" />
-      )}
+      {profileIsLoading && <Skeleton className="h-25 w-full" />}
       {profileError && (
-        <div
-          className="bg-white rounded-xl p-2.5 shadow-sm h-fit w-full justify-center items-center"
-        >
-          <ErrorBodyComponent error={profileError} size={ErrorBodyComponentSize.Small} position={ErrorBodyComponentPosition.Centered} onRefreshClick={() => profileRefetch()} />
+        <div className="bg-white rounded-xl p-2.5 shadow-sm h-fit w-full justify-center items-center">
+          <ErrorBodyComponent
+            error={profileError}
+            size={ErrorBodyComponentSize.Small}
+            position={ErrorBodyComponentPosition.Centered}
+            onRefreshClick={() => profileRefetch()}
+          />
         </div>
       )}
       {profileData && (
@@ -142,10 +147,13 @@ export const ProfilePage = () => {
             return <SkeletonGoalCard key={`skeletonGoalCard_${idx}`} />
           })}
         {goalsError && (
-          <div
-            className="bg-white rounded-xl p-2.5 shadow-sm h-fit w-full justify-center items-center"
-          >
-            <ErrorBodyComponent error={goalsError} size={ErrorBodyComponentSize.Small} position={ErrorBodyComponentPosition.Centered} onRefreshClick={() => goalsRefetch()} />
+          <div className="bg-white rounded-xl p-2.5 shadow-sm h-fit w-full justify-center items-center">
+            <ErrorBodyComponent
+              error={goalsError}
+              size={ErrorBodyComponentSize.Small}
+              position={ErrorBodyComponentPosition.Centered}
+              onRefreshClick={() => goalsRefetch()}
+            />
           </div>
         )}
       </div>

--- a/apps/client/src/features/profile/ProfilePage.tsx
+++ b/apps/client/src/features/profile/ProfilePage.tsx
@@ -13,6 +13,8 @@ import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import { TopBarConfig } from '@/components/custom/TopBar'
 import { useCurrentYear } from '@/hooks/useCurrentDate'
 import { getInitials } from '@/lib/stringUtils'
+import { Skeleton } from '@/components/ui/skeleton'
+import { ErrorBodyComponent, ErrorBodyComponentPosition, ErrorBodyComponentSize } from '@/components/custom/ErrorComponents'
 
 export const ProfilePage = () => {
   const navigate = useNavigate()
@@ -24,12 +26,11 @@ export const ProfilePage = () => {
   const { profileName } = route.useParams()
   const profileNameInitials = getInitials(profileName)
 
-  // Un-used variables to be addressed in #12
-  /* eslint-disable @typescript-eslint/no-unused-vars */
   const {
     data: profileData,
     isLoading: profileIsLoading,
     error: profileError,
+    refetch: profileRefetch,
   } = useProfile(profileName)
   const isProfilePrivate =
     profileData?.joinedAt === undefined &&
@@ -39,8 +40,8 @@ export const ProfilePage = () => {
     data: goalsData,
     isLoading: goalsIsLoading,
     error: goalsError,
+    refetch: goalsRefetch,
   } = useProfileGoals(profileName)
-  /* eslint-enable @typescript-eslint/no-unused-vars */
 
   const formatDateToString = (date: Date | undefined) => {
     return date ? `${date}` : undefined
@@ -71,6 +72,16 @@ export const ProfilePage = () => {
       />
 
       {/* Profile data */}
+      {profileIsLoading && (
+        <Skeleton className="h-25 w-full" />
+      )}
+      {profileError && (
+        <div
+          className="bg-white rounded-xl p-2.5 shadow-sm h-fit w-full justify-center items-center"
+        >
+          <ErrorBodyComponent error={profileError} size={ErrorBodyComponentSize.Small} position={ErrorBodyComponentPosition.Centered} onRefreshClick={() => profileRefetch()} />
+        </div>
+      )}
       {profileData && (
         <div className="bg-white rounded-xl p-2.5 flex flex-row gap-3">
           <Avatar className="size-20">
@@ -111,28 +122,33 @@ export const ProfilePage = () => {
       )}
 
       {/* Goals data/ heatmaps container */}
-      {(goalsData || goalsIsLoading) && (
-        <div className="flex flex-col gap-3">
-          {goalsData &&
-            goalsData.map((d) => {
-              return (
-                <GoalCardDescriptive
-                  key={`goalCard_${d.id}`}
-                  title={d.title}
-                  description={d.description}
-                  iconName={d.icon as IconName}
-                  goalData={d}
-                  selectedYear={selectedYear}
-                  viewOnly={true}
-                />
-              )
-            })}
-          {goalsIsLoading &&
-            [...Array(3)].map((_, idx) => {
-              return <SkeletonGoalCard key={`skeletonGoalCard_${idx}`} />
-            })}
-        </div>
-      )}
+      <div className="flex flex-col gap-3">
+        {goalsData &&
+          goalsData.map((d) => {
+            return (
+              <GoalCardDescriptive
+                key={`goalCard_${d.id}`}
+                title={d.title}
+                description={d.description}
+                iconName={d.icon as IconName}
+                goalData={d}
+                selectedYear={selectedYear}
+                viewOnly={true}
+              />
+            )
+          })}
+        {goalsIsLoading &&
+          [...Array(3)].map((_, idx) => {
+            return <SkeletonGoalCard key={`skeletonGoalCard_${idx}`} />
+          })}
+        {goalsError && (
+          <div
+            className="bg-white rounded-xl p-2.5 shadow-sm h-fit w-full justify-center items-center"
+          >
+            <ErrorBodyComponent error={goalsError} size={ErrorBodyComponentSize.Small} position={ErrorBodyComponentPosition.Centered} onRefreshClick={() => goalsRefetch()} />
+          </div>
+        )}
+      </div>
     </div>
   )
 }

--- a/apps/client/src/features/settings/AccountDetailsPage.tsx
+++ b/apps/client/src/features/settings/AccountDetailsPage.tsx
@@ -9,10 +9,14 @@ import type {
 } from '@habit-tracker/validation-schemas'
 import { TopBarClose } from '@/components/custom/TopBar'
 import {
+  ErrorBodyComponent,
+  ErrorBodyComponentPosition,
+  ErrorBodyComponentSize,
   ErrorDialogCategory,
   ErrorDialogComponent,
 } from '@/components/custom/ErrorComponents'
 import { Button } from '@/components/ui/button'
+import { Spinner } from '@/components/ui/spinner'
 
 const UpdateUserFormSchema = z
   .object({
@@ -35,16 +39,14 @@ const UpdateUserFormSchema = z
 type UpdateUserFormType = z.infer<typeof UpdateUserFormSchema>
 
 interface AccountDetailsFormProps {
-  defaultValues: UserResponseDto
+  defaultValues: UserResponseDto,
+  closeCallback: () => void
 }
 
 const AccountDetailsForm: React.FC<AccountDetailsFormProps> = ({
   defaultValues,
+  closeCallback
 }) => {
-  const navigate = useNavigate()
-  const router = useRouter()
-  const canGoBack = useCanGoBack()
-
   const initialValues: UpdateUserFormType = defaultValues
 
   const { mutate: updateUserMutateFn } = useUpdateUserMutation()
@@ -52,14 +54,6 @@ const AccountDetailsForm: React.FC<AccountDetailsFormProps> = ({
   const [displayedError, setDisplayedError] = useState<
     { category: ErrorDialogCategory; error: Error } | undefined
   >(undefined)
-
-  const navigateBack = () => {
-    if (canGoBack) {
-      router.history.back()
-    } else {
-      navigate({ to: '/settings' })
-    }
-  }
 
   const form = useAppForm({
     defaultValues: initialValues,
@@ -75,7 +69,7 @@ const AccountDetailsForm: React.FC<AccountDetailsFormProps> = ({
       updateUserMutateFn(
         { update: updateValue },
         {
-          onSuccess: navigateBack,
+          onSuccess: closeCallback,
           onError: (error) =>
             setDisplayedError({
               error: error,
@@ -87,9 +81,7 @@ const AccountDetailsForm: React.FC<AccountDetailsFormProps> = ({
   })
 
   return (
-    <div className="flex flex-col gap-3">
-      {/* Topbar config */}
-      <TopBarClose title="Account Details" closeCallback={navigateBack} />
+    <>
       {/* Form controls container */}
       <form
         onSubmit={(e) => {
@@ -121,7 +113,7 @@ const AccountDetailsForm: React.FC<AccountDetailsFormProps> = ({
 
         <div className="flex justify-end">
           <form.AppForm>
-            <Button type="button" variant={'ghost'} onClick={navigateBack}>
+            <Button type="button" variant={'ghost'} onClick={closeCallback}>
               Cancel
             </Button>
             <form.SubscribeButton label={'Save'} />
@@ -137,21 +129,32 @@ const AccountDetailsForm: React.FC<AccountDetailsFormProps> = ({
           }}
         />
       )}
-    </div>
+    </>
   )
 }
 
 export function AccountDetailsPage() {
-  const { data, isLoading, error } = useUser()
+  const { data, isLoading, error, refetch: userRefetch } = useUser()
+  const navigate = useNavigate()
+  const router = useRouter()
+  const canGoBack = useCanGoBack()
+
+  const navigateBack = () => {
+    if (canGoBack) {
+      router.history.back()
+    } else {
+      navigate({ to: '/goals' })
+    }
+  }
 
   return (
-    <>
-      {isLoading && <div>Loading...</div>}
-      {/* // TODOs #12 Improve loading display + error display */}
-      {error && <div>{error.message}</div>}
-      {!isLoading && !error && data && (
-        <AccountDetailsForm defaultValues={data} />
-      )}
-    </>
+    <div className="flex flex-col gap-3">
+      <TopBarClose title="Account Details" closeCallback={navigateBack} />
+      {isLoading && <div className="flex justify-center items-center w-full h-full">
+        <Spinner className="size-28" />
+      </div>}
+      {error && <ErrorBodyComponent error={error} size={ErrorBodyComponentSize.Small} position={ErrorBodyComponentPosition.Centered} onRefreshClick={() => userRefetch()} />}
+      {!isLoading && !error && data && <AccountDetailsForm defaultValues={data} closeCallback={navigateBack}/>}
+    </div>
   )
 }

--- a/apps/client/src/features/settings/AccountDetailsPage.tsx
+++ b/apps/client/src/features/settings/AccountDetailsPage.tsx
@@ -39,13 +39,13 @@ const UpdateUserFormSchema = z
 type UpdateUserFormType = z.infer<typeof UpdateUserFormSchema>
 
 interface AccountDetailsFormProps {
-  defaultValues: UserResponseDto,
+  defaultValues: UserResponseDto
   closeCallback: () => void
 }
 
 const AccountDetailsForm: React.FC<AccountDetailsFormProps> = ({
   defaultValues,
-  closeCallback
+  closeCallback,
 }) => {
   const initialValues: UpdateUserFormType = defaultValues
 
@@ -150,11 +150,22 @@ export function AccountDetailsPage() {
   return (
     <div className="flex flex-col gap-3">
       <TopBarClose title="Account Details" closeCallback={navigateBack} />
-      {isLoading && <div className="flex justify-center items-center w-full h-full">
-        <Spinner className="size-28" />
-      </div>}
-      {error && <ErrorBodyComponent error={error} size={ErrorBodyComponentSize.Small} position={ErrorBodyComponentPosition.Centered} onRefreshClick={() => userRefetch()} />}
-      {!isLoading && !error && data && <AccountDetailsForm defaultValues={data} closeCallback={navigateBack}/>}
+      {isLoading && (
+        <div className="flex justify-center items-center w-full h-full">
+          <Spinner className="size-28" />
+        </div>
+      )}
+      {error && (
+        <ErrorBodyComponent
+          error={error}
+          size={ErrorBodyComponentSize.Small}
+          position={ErrorBodyComponentPosition.Centered}
+          onRefreshClick={() => userRefetch()}
+        />
+      )}
+      {!isLoading && !error && data && (
+        <AccountDetailsForm defaultValues={data} closeCallback={navigateBack} />
+      )}
     </div>
   )
 }

--- a/apps/client/src/features/settings/DeleteAccountPage.tsx
+++ b/apps/client/src/features/settings/DeleteAccountPage.tsx
@@ -19,11 +19,14 @@ import { Spinner } from '@/components/ui/spinner'
 // - Fix `value` prop on `input` should not be null. Consider using an empty string to clear the component or `undefined` for uncontrolled components.
 
 interface DeleteAccountFormProps {
-  user: UserResponseDto | null | undefined,
-  closeCallback: () => void,
+  user: UserResponseDto | null | undefined
+  closeCallback: () => void
 }
 
-const DeleteAccountForm: React.FC<DeleteAccountFormProps> = ({ user, closeCallback }) => {
+const DeleteAccountForm: React.FC<DeleteAccountFormProps> = ({
+  user,
+  closeCallback,
+}) => {
   const navigate = useNavigate()
 
   const DeleteFormSchema = z
@@ -140,11 +143,22 @@ export function DeleteAccountPage() {
     <div className="flex flex-col gap-3">
       {/* Topbar config */}
       <TopBarClose title="Delete Account" closeCallback={navigateBack} />
-      {isLoading && <div className="flex justify-center items-center w-full h-full">
-        <Spinner className="size-28" />
-      </div>}
-      {error && <ErrorBodyComponent error={error} size={ErrorBodyComponentSize.Small} position={ErrorBodyComponentPosition.Centered} onRefreshClick={() => userRefetch()} />}
-      {!isLoading && !error && <DeleteAccountForm user={data} closeCallback={navigateBack}/>}
+      {isLoading && (
+        <div className="flex justify-center items-center w-full h-full">
+          <Spinner className="size-28" />
+        </div>
+      )}
+      {error && (
+        <ErrorBodyComponent
+          error={error}
+          size={ErrorBodyComponentSize.Small}
+          position={ErrorBodyComponentPosition.Centered}
+          onRefreshClick={() => userRefetch()}
+        />
+      )}
+      {!isLoading && !error && (
+        <DeleteAccountForm user={data} closeCallback={navigateBack} />
+      )}
     </div>
   )
 }

--- a/apps/client/src/features/settings/DeleteAccountPage.tsx
+++ b/apps/client/src/features/settings/DeleteAccountPage.tsx
@@ -6,22 +6,25 @@ import { useDeleteUserMutation, useUser } from '../../apis/UserApi'
 import type { UserResponseDto } from '@habit-tracker/validation-schemas'
 import { TopBarClose } from '@/components/custom/TopBar'
 import {
+  ErrorBodyComponent,
+  ErrorBodyComponentPosition,
+  ErrorBodyComponentSize,
   ErrorDialogCategory,
   ErrorDialogComponent,
 } from '@/components/custom/ErrorComponents'
 import { Button } from '@/components/ui/button'
+import { Spinner } from '@/components/ui/spinner'
 
 // TODOs #11:
 // - Fix `value` prop on `input` should not be null. Consider using an empty string to clear the component or `undefined` for uncontrolled components.
 
 interface DeleteAccountFormProps {
-  user: UserResponseDto | null | undefined
+  user: UserResponseDto | null | undefined,
+  closeCallback: () => void,
 }
 
-const DeleteAccountForm: React.FC<DeleteAccountFormProps> = ({ user }) => {
+const DeleteAccountForm: React.FC<DeleteAccountFormProps> = ({ user, closeCallback }) => {
   const navigate = useNavigate()
-  const router = useRouter()
-  const canGoBack = useCanGoBack()
 
   const DeleteFormSchema = z
     .object({
@@ -42,14 +45,6 @@ const DeleteAccountForm: React.FC<DeleteAccountFormProps> = ({ user }) => {
   const [displayedError, setDisplayedError] = useState<
     { category: ErrorDialogCategory; error: Error } | undefined
   >(undefined)
-
-  const navigateBack = () => {
-    if (canGoBack) {
-      router.history.back()
-    } else {
-      navigate({ to: '/goals' })
-    }
-  }
 
   const form = useAppForm({
     defaultValues: {
@@ -74,10 +69,7 @@ const DeleteAccountForm: React.FC<DeleteAccountFormProps> = ({ user }) => {
   })
 
   return (
-    <div className="flex flex-col gap-3">
-      {/* Topbar config */}
-      <TopBarClose title="Delete Account" closeCallback={navigateBack} />
-      {/* Form controls container */}
+    <>
       <form
         onSubmit={(e) => {
           e.preventDefault()
@@ -110,7 +102,7 @@ const DeleteAccountForm: React.FC<DeleteAccountFormProps> = ({ user }) => {
 
         <div className="flex justify-end">
           <form.AppForm>
-            <Button type="button" variant={'ghost'} onClick={navigateBack}>
+            <Button type="button" variant={'ghost'} onClick={closeCallback}>
               Cancel
             </Button>
             <form.SubscribeButton variant={'destructive'} label={'Delete'} />
@@ -126,18 +118,33 @@ const DeleteAccountForm: React.FC<DeleteAccountFormProps> = ({ user }) => {
           }}
         />
       )}
-    </div>
+    </>
   )
 }
 
 export function DeleteAccountPage() {
-  const { data, isLoading, error } = useUser()
+  const { data, isLoading, error, refetch: userRefetch } = useUser()
+  const navigate = useNavigate()
+  const router = useRouter()
+  const canGoBack = useCanGoBack()
+
+  const navigateBack = () => {
+    if (canGoBack) {
+      router.history.back()
+    } else {
+      navigate({ to: '/goals' })
+    }
+  }
 
   return (
-    <>
-      {isLoading && <div>Loading...</div>}
-      {error && <div>{error.message}</div>}
-      {!isLoading && !error && <DeleteAccountForm user={data} />}
-    </>
+    <div className="flex flex-col gap-3">
+      {/* Topbar config */}
+      <TopBarClose title="Delete Account" closeCallback={navigateBack} />
+      {isLoading && <div className="flex justify-center items-center w-full h-full">
+        <Spinner className="size-28" />
+      </div>}
+      {error && <ErrorBodyComponent error={error} size={ErrorBodyComponentSize.Small} position={ErrorBodyComponentPosition.Centered} onRefreshClick={() => userRefetch()} />}
+      {!isLoading && !error && <DeleteAccountForm user={data} closeCallback={navigateBack}/>}
+    </div>
   )
 }

--- a/apps/client/src/features/settings/GoalOrderPage.tsx
+++ b/apps/client/src/features/settings/GoalOrderPage.tsx
@@ -185,9 +185,8 @@ export function GoalOrderPage() {
       // No issues during parsing, hence send to backend
       reorderGoalsMutateFn(reorderData, {
         onSuccess: navigateBack,
-        onError: (err) => console.log('Error on reordering', err),
-        // TODOs #8 toast? Error modal?
-        // TODOs #12 Improve loading display + error display
+        // Note: generic error snackbar/ toast will appear,
+        // hence deliberately not using onError
       })
     }
   }

--- a/apps/client/src/features/settings/SettingsPage.tsx
+++ b/apps/client/src/features/settings/SettingsPage.tsx
@@ -71,9 +71,7 @@ type SettingItem =
 export function SettingsPage() {
   const navigate = useNavigate()
 
-  // Un-used variables to be addressed in #12
-  /* eslint-disable @typescript-eslint/no-unused-vars */
-  const { data: userData, isLoading: userLoading, error: userError } = useUser()
+  const { data: userData } = useUser()
   const updateUserMutation = useUpdateUserMutation()
 
   const userPublicity = userData?.profilePublicity

--- a/apps/client/src/hooks/useSmartBack.ts
+++ b/apps/client/src/hooks/useSmartBack.ts
@@ -1,0 +1,17 @@
+import { useCanGoBack, useNavigate, useRouter } from "@tanstack/react-router"
+
+export function useSmartBack(fallback: string = '/goals') {
+  const navigate = useNavigate()
+  const router = useRouter()
+  const canGoBack = useCanGoBack()
+  
+  const navigateBack = () => {
+    if (canGoBack) {
+      router.history.back()
+    } else {
+      navigate({ to: fallback })
+    }
+  }
+
+  return navigateBack;
+}

--- a/apps/client/src/hooks/useSmartBack.ts
+++ b/apps/client/src/hooks/useSmartBack.ts
@@ -1,10 +1,10 @@
-import { useCanGoBack, useNavigate, useRouter } from "@tanstack/react-router"
+import { useCanGoBack, useNavigate, useRouter } from '@tanstack/react-router'
 
 export function useSmartBack(fallback: string = '/goals') {
   const navigate = useNavigate()
   const router = useRouter()
   const canGoBack = useCanGoBack()
-  
+
   const navigateBack = () => {
     if (canGoBack) {
       router.history.back()
@@ -13,5 +13,5 @@ export function useSmartBack(fallback: string = '/goals') {
     }
   }
 
-  return navigateBack;
+  return navigateBack
 }

--- a/apps/client/src/integrations/tanstack-query/root-provider.tsx
+++ b/apps/client/src/integrations/tanstack-query/root-provider.tsx
@@ -1,6 +1,13 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { QueryCache, QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { toast } from 'sonner'
 
-export const queryClient = new QueryClient()
+export const queryClient = new QueryClient({
+  queryCache: new QueryCache({
+    onError: (error) => {
+      toast(`Something went wrong: ${error.message}`)
+    }
+  }),
+})
 
 export function getContext() {
   return {

--- a/apps/client/src/integrations/tanstack-query/root-provider.tsx
+++ b/apps/client/src/integrations/tanstack-query/root-provider.tsx
@@ -1,10 +1,34 @@
+import { clearAuthUser } from '@/apis/UserApi'
 import { triggerErrorToast } from '@/components/custom/ErrorComponents'
-import { MutationCache, QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MutationCache, QueryCache, QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { redirect } from '@tanstack/react-router'
+import { HTTPError } from 'ky'
 
+// Handle mid-way unauthorized errors,
+// by checking for 401 status and if so,
+// clear user auth and redirect to login page
 export const queryClient = new QueryClient({
+  queryCache: new QueryCache({
+    onError: (error: unknown, query) => {
+      console.error(`Query ${query.options.queryKey ?? '<unknown query>'} failed:`, error)
+
+      if (error instanceof HTTPError && error.response.status === 401) {
+        clearAuthUser()
+        throw redirect({ to: '/login' }) // TODOs #12 fix this; ideally redirect via router.navigate instead of redirect (intended for loader/beforeLoad)
+      }
+
+      triggerErrorToast(error)
+    }
+  }),
   mutationCache: new MutationCache({
     onError: (error: unknown, _variables, _context, mutation) => {
       console.error(`Mutation ${mutation.options.mutationKey ?? '<unknown mutation>'} failed:`, error)
+
+      if (error instanceof HTTPError && error.response.status === 401) {
+        clearAuthUser()
+        throw redirect({ to: '/login' }) // TODOs #12 fix this; ideally redirect via router.navigate instead of redirect (intended for loader/beforeLoad)
+      }
+
       triggerErrorToast(error)
     }
   }),

--- a/apps/client/src/integrations/tanstack-query/root-provider.tsx
+++ b/apps/client/src/integrations/tanstack-query/root-provider.tsx
@@ -1,10 +1,11 @@
-import { QueryCache, QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { toast } from 'sonner'
+import { triggerErrorToast } from '@/components/custom/ErrorComponents'
+import { MutationCache, QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 export const queryClient = new QueryClient({
-  queryCache: new QueryCache({
-    onError: (error) => {
-      toast(`Something went wrong: ${error.message}`)
+  mutationCache: new MutationCache({
+    onError: (error: unknown, _variables, _context, mutation) => {
+      console.error(`Mutation ${mutation.options.mutationKey ?? '<unknown mutation>'} failed:`, error)
+      triggerErrorToast(error)
     }
   }),
 })

--- a/apps/client/src/integrations/tanstack-query/root-provider.tsx
+++ b/apps/client/src/integrations/tanstack-query/root-provider.tsx
@@ -1,8 +1,8 @@
-import { clearAuthUser } from '@/apis/UserApi'
-import { triggerErrorToast } from '@/components/custom/ErrorComponents'
 import { MutationCache, QueryCache, QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { redirect } from '@tanstack/react-router'
 import { HTTPError } from 'ky'
+import { triggerErrorToast } from '@/components/custom/ErrorComponents'
+import { clearAuthUser } from '@/apis/UserApi'
 
 // Handle mid-way unauthorized errors,
 // by checking for 401 status and if so,

--- a/apps/client/src/integrations/tanstack-query/root-provider.tsx
+++ b/apps/client/src/integrations/tanstack-query/root-provider.tsx
@@ -14,7 +14,7 @@ export const queryClient = new QueryClient({
 
       if (error instanceof HTTPError && error.response.status === 401) {
         clearAuthUser()
-        throw redirect({ to: '/login' }) // TODOs #12 fix this; ideally redirect via router.navigate instead of redirect (intended for loader/beforeLoad)
+        throw redirect({ to: '/login' })
       }
 
       triggerErrorToast(error)
@@ -26,7 +26,7 @@ export const queryClient = new QueryClient({
 
       if (error instanceof HTTPError && error.response.status === 401) {
         clearAuthUser()
-        throw redirect({ to: '/login' }) // TODOs #12 fix this; ideally redirect via router.navigate instead of redirect (intended for loader/beforeLoad)
+        throw redirect({ to: '/login' })
       }
 
       triggerErrorToast(error)

--- a/apps/client/src/integrations/tanstack-query/root-provider.tsx
+++ b/apps/client/src/integrations/tanstack-query/root-provider.tsx
@@ -1,4 +1,9 @@
-import { MutationCache, QueryCache, QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  MutationCache,
+  QueryCache,
+  QueryClient,
+  QueryClientProvider,
+} from '@tanstack/react-query'
 import { redirect } from '@tanstack/react-router'
 import { HTTPError } from 'ky'
 import { triggerErrorToast } from '@/components/custom/ErrorComponents'
@@ -10,7 +15,10 @@ import { clearAuthUser } from '@/apis/UserApi'
 export const queryClient = new QueryClient({
   queryCache: new QueryCache({
     onError: (error: unknown, query) => {
-      console.error(`Query ${query.options.queryKey ?? '<unknown query>'} failed:`, error)
+      console.error(
+        `Query ${query.options.queryKey ?? '<unknown query>'} failed:`,
+        error,
+      )
 
       if (error instanceof HTTPError && error.response.status === 401) {
         clearAuthUser()
@@ -18,11 +26,14 @@ export const queryClient = new QueryClient({
       }
 
       triggerErrorToast(error)
-    }
+    },
   }),
   mutationCache: new MutationCache({
     onError: (error: unknown, _variables, _context, mutation) => {
-      console.error(`Mutation ${mutation.options.mutationKey ?? '<unknown mutation>'} failed:`, error)
+      console.error(
+        `Mutation ${mutation.options.mutationKey ?? '<unknown mutation>'} failed:`,
+        error,
+      )
 
       if (error instanceof HTTPError && error.response.status === 401) {
         clearAuthUser()
@@ -30,7 +41,7 @@ export const queryClient = new QueryClient({
       }
 
       triggerErrorToast(error)
-    }
+    },
   }),
 })
 

--- a/apps/client/src/main.tsx
+++ b/apps/client/src/main.tsx
@@ -11,6 +11,7 @@ import './styles.css'
 import reportWebVitals from './reportWebVitals.ts'
 import { Toaster } from 'sonner'
 import { Spinner } from './components/ui/spinner.tsx'
+import { NotFoundComponent } from './components/custom/NotFoundComponent.tsx'
 
 // Create a new router instance
 const router = createRouter({
@@ -28,6 +29,10 @@ const router = createRouter({
   defaultPendingComponent: () => <div className="flex justify-center items-center w-full h-full">
     <Spinner className="size-28" />
   </div>,
+  defaultNotFoundComponent: () => <NotFoundComponent />,
+  defaultErrorComponent: () => <div>
+    ERROR COMPOENT DEFAULT
+  </div>
 })
 
 // Register the router instance for type safety

--- a/apps/client/src/main.tsx
+++ b/apps/client/src/main.tsx
@@ -10,6 +10,7 @@ import { routeTree } from './routeTree.gen.ts'
 import './styles.css'
 import reportWebVitals from './reportWebVitals.ts'
 import { Toaster } from 'sonner'
+import { Spinner } from './components/ui/spinner.tsx'
 
 // Create a new router instance
 const router = createRouter({
@@ -24,7 +25,9 @@ const router = createRouter({
   // TODOs #23 investigate slow loading
   defaultPendingMs: 0,
   defaultPendingMinMs: 0,
-  defaultPendingComponent: () => 'loading...',
+  defaultPendingComponent: () => <div className="flex justify-center items-center w-full h-full">
+    <Spinner className="size-28" />
+  </div>,
 })
 
 // Register the router instance for type safety

--- a/apps/client/src/main.tsx
+++ b/apps/client/src/main.tsx
@@ -9,6 +9,7 @@ import { routeTree } from './routeTree.gen.ts'
 
 import './styles.css'
 import reportWebVitals from './reportWebVitals.ts'
+import { Toaster } from 'sonner'
 
 // Create a new router instance
 const router = createRouter({
@@ -43,7 +44,10 @@ if (rootElement && !rootElement.innerHTML) {
   root.render(
     <StrictMode>
       <TanStackQueryProvider.Provider>
+        {/* Routes */}
         <RouterProvider router={router} />
+        {/* Global toast, not part of any particular route */}
+        <Toaster />
       </TanStackQueryProvider.Provider>
     </StrictMode>,
   )

--- a/apps/client/src/main.tsx
+++ b/apps/client/src/main.tsx
@@ -24,8 +24,8 @@ const router = createRouter({
   defaultStructuralSharing: true,
   defaultPreloadStaleTime: 0,
   // TODOs #23 investigate slow loading
-  defaultPendingMs: 0,
-  defaultPendingMinMs: 0,
+  defaultPendingMs: 1000,
+  defaultPendingMinMs: 500,
   defaultPendingComponent: () => <div className="flex justify-center items-center w-full h-full">
     <Spinner className="size-28" />
   </div>,

--- a/apps/client/src/main.tsx
+++ b/apps/client/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react'
 import ReactDOM from 'react-dom/client'
 import { RouterProvider, createRouter } from '@tanstack/react-router'
+import { Toaster } from 'sonner'
 
 import * as TanStackQueryProvider from './integrations/tanstack-query/root-provider.tsx'
 
@@ -9,7 +10,6 @@ import { routeTree } from './routeTree.gen.ts'
 
 import './styles.css'
 import reportWebVitals from './reportWebVitals.ts'
-import { Toaster } from 'sonner'
 import { Spinner } from './components/ui/spinner.tsx'
 import { NotFoundComponent } from './components/custom/NotFoundComponent.tsx'
 

--- a/apps/client/src/main.tsx
+++ b/apps/client/src/main.tsx
@@ -26,13 +26,13 @@ const router = createRouter({
   // TODOs #23 investigate slow loading
   defaultPendingMs: 1000,
   defaultPendingMinMs: 500,
-  defaultPendingComponent: () => <div className="flex justify-center items-center w-full h-full">
-    <Spinner className="size-28" />
-  </div>,
+  defaultPendingComponent: () => (
+    <div className="flex justify-center items-center w-full h-full">
+      <Spinner className="size-28" />
+    </div>
+  ),
   defaultNotFoundComponent: () => <NotFoundComponent />,
-  defaultErrorComponent: () => <div>
-    ERROR COMPOENT DEFAULT
-  </div>
+  defaultErrorComponent: () => <div>ERROR COMPOENT DEFAULT</div>,
 })
 
 // Register the router instance for type safety

--- a/apps/client/src/routes/__root.tsx
+++ b/apps/client/src/routes/__root.tsx
@@ -8,6 +8,7 @@ import TanStackQueryLayout from '../integrations/tanstack-query/layout.tsx'
 import type { QueryClient } from '@tanstack/react-query'
 import { queryClient } from '@/integrations/tanstack-query/root-provider.tsx'
 import { fetchUser } from '@/apis/UserApi.ts'
+import { ErrorBodyComponent } from '@/components/custom/ErrorComponents.tsx'
 
 interface MyRouterContext {
   queryClient: QueryClient
@@ -48,4 +49,13 @@ export const Route = createRootRouteWithContext<MyRouterContext>()({
       throw redirect({ to: '/login' })
     }
   },
+  errorComponent: ({ error }) => {
+    return <ErrorBodyComponent
+      error={error}
+      onRefreshClick={() => {
+        // Reload current web page
+        window.location.reload(); 
+      }}
+    />
+  }
 })

--- a/apps/client/src/routes/__root.tsx
+++ b/apps/client/src/routes/__root.tsx
@@ -6,20 +6,11 @@ import {
 import { TanStackRouterDevtools } from '@tanstack/react-router-devtools'
 import TanStackQueryLayout from '../integrations/tanstack-query/layout.tsx'
 import type { QueryClient } from '@tanstack/react-query'
-import { queryClient } from '@/integrations/tanstack-query/root-provider.tsx'
-import { fetchUser } from '@/apis/UserApi.ts'
 import { ErrorBodyComponent } from '@/components/custom/ErrorComponents.tsx'
+import { checkAuthUser, clearAuthUser } from '@/apis/UserApi.ts'
 
 interface MyRouterContext {
   queryClient: QueryClient
-}
-
-export async function checkAuthUser() {
-  const user = await queryClient.ensureQueryData({
-    queryKey: ['user'],
-    queryFn: fetchUser,
-  })
-  return user
 }
 
 export const Route = createRootRouteWithContext<MyRouterContext>()({
@@ -41,10 +32,13 @@ export const Route = createRootRouteWithContext<MyRouterContext>()({
     // Allow /profile and anything under it
     const isProfilePath = location.pathname.startsWith('/profile')
 
+    // Handle starting-way unauthorized errors on route load,
+    // by checking whether user is logged in and whether route is public, and if not
+    // redirect to login page
+    const isPublicPath = publicPaths.includes(location.pathname) || isProfilePath;
     if (
       !isLoggedInUser &&
-      !publicPaths.includes(location.pathname) &&
-      !isProfilePath
+      !isPublicPath
     ) {
       throw redirect({ to: '/login' })
     }

--- a/apps/client/src/routes/__root.tsx
+++ b/apps/client/src/routes/__root.tsx
@@ -7,7 +7,7 @@ import { TanStackRouterDevtools } from '@tanstack/react-router-devtools'
 import TanStackQueryLayout from '../integrations/tanstack-query/layout.tsx'
 import type { QueryClient } from '@tanstack/react-query'
 import { ErrorBodyComponent } from '@/components/custom/ErrorComponents.tsx'
-import { checkAuthUser, clearAuthUser } from '@/apis/UserApi.ts'
+import { checkAuthUser } from '@/apis/UserApi.ts'
 
 interface MyRouterContext {
   queryClient: QueryClient

--- a/apps/client/src/routes/__root.tsx
+++ b/apps/client/src/routes/__root.tsx
@@ -35,21 +35,21 @@ export const Route = createRootRouteWithContext<MyRouterContext>()({
     // Handle starting-way unauthorized errors on route load,
     // by checking whether user is logged in and whether route is public, and if not
     // redirect to login page
-    const isPublicPath = publicPaths.includes(location.pathname) || isProfilePath;
-    if (
-      !isLoggedInUser &&
-      !isPublicPath
-    ) {
+    const isPublicPath =
+      publicPaths.includes(location.pathname) || isProfilePath
+    if (!isLoggedInUser && !isPublicPath) {
       throw redirect({ to: '/login' })
     }
   },
   errorComponent: ({ error }) => {
-    return <ErrorBodyComponent
-      error={error}
-      onRefreshClick={() => {
-        // Reload current web page
-        window.location.reload(); 
-      }}
-    />
-  }
+    return (
+      <ErrorBodyComponent
+        error={error}
+        onRefreshClick={() => {
+          // Reload current web page
+          window.location.reload()
+        }}
+      />
+    )
+  },
 })

--- a/apps/client/src/routes/goals_/$goalId_.edit.tsx
+++ b/apps/client/src/routes/goals_/$goalId_.edit.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { GoalEditPage, SkeletonGoalForm } from '@/features/goals/GoalCreatePage'
+import { GoalEditPage, SkeletonGoalEditPage } from '@/features/goals/GoalCreatePage'
 
 export const Route = createFileRoute('/goals_/$goalId_/edit')({
   component: GoalEditPage,
-  pendingComponent: SkeletonGoalForm,
+  pendingComponent: SkeletonGoalEditPage,
 })

--- a/apps/client/src/routes/goals_/$goalId_.edit.tsx
+++ b/apps/client/src/routes/goals_/$goalId_.edit.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { GoalEditPage } from '@/features/goals/GoalCreatePage'
+import { GoalEditPage, SkeletonGoalForm } from '@/features/goals/GoalCreatePage'
 
 export const Route = createFileRoute('/goals_/$goalId_/edit')({
   component: GoalEditPage,
+  pendingComponent: SkeletonGoalForm,
 })

--- a/apps/client/src/routes/goals_/$goalId_.edit.tsx
+++ b/apps/client/src/routes/goals_/$goalId_.edit.tsx
@@ -1,5 +1,8 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { GoalEditPage, SkeletonGoalEditPage } from '@/features/goals/GoalCreatePage'
+import {
+  GoalEditPage,
+  SkeletonGoalEditPage,
+} from '@/features/goals/GoalCreatePage'
 
 export const Route = createFileRoute('/goals_/$goalId_/edit')({
   component: GoalEditPage,

--- a/apps/client/src/routes/goals_/create.tsx
+++ b/apps/client/src/routes/goals_/create.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { GoalCreatePage, SkeletonGoalForm } from '@/features/goals/GoalCreatePage'
+import { GoalCreatePage, SkeletonGoalCreatePage } from '@/features/goals/GoalCreatePage'
 
 export const Route = createFileRoute('/goals_/create')({
   component: GoalCreatePage,
-  pendingComponent: SkeletonGoalForm,
+  pendingComponent: SkeletonGoalCreatePage,
 })

--- a/apps/client/src/routes/goals_/create.tsx
+++ b/apps/client/src/routes/goals_/create.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { GoalCreatePage } from '@/features/goals/GoalCreatePage'
+import { GoalCreatePage, SkeletonGoalForm } from '@/features/goals/GoalCreatePage'
 
 export const Route = createFileRoute('/goals_/create')({
   component: GoalCreatePage,
+  pendingComponent: SkeletonGoalForm,
 })

--- a/apps/client/src/routes/goals_/create.tsx
+++ b/apps/client/src/routes/goals_/create.tsx
@@ -1,5 +1,8 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { GoalCreatePage, SkeletonGoalCreatePage } from '@/features/goals/GoalCreatePage'
+import {
+  GoalCreatePage,
+  SkeletonGoalCreatePage,
+} from '@/features/goals/GoalCreatePage'
 
 export const Route = createFileRoute('/goals_/create')({
   component: GoalCreatePage,

--- a/package-lock.json
+++ b/package-lock.json
@@ -118,10 +118,12 @@
         "date-fns": "^4.1.0",
         "ky": "^1.8.1",
         "lucide-react": "^0.476.0",
+        "next-themes": "^0.4.6",
         "react": "^19.0.0",
         "react-day-picker": "^9.8.0",
         "react-dom": "^19.0.0",
         "recharts": "^3.0.2",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.0.2",
         "tailwindcss": "^4.0.6",
         "tailwindcss-animate": "^1.0.7"
@@ -15220,6 +15222,15 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "devOptional": true
     },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/node-abort-controller": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
@@ -16997,6 +17008,15 @@
       },
       "peerDependencies": {
         "seroval": "^1.0"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/sort-keys": {


### PR DESCRIPTION
Updated components to better handle loading + error state.

`apis`:
- `GoalApi`: added mutation keys to all mutations
- `UserApi`: added `checkAuthUser` function for determining if user is logged in (returns null if unauthorized)

`components/custom`:
- `DialogComponents`: added delete loading swirly on button
- `ErrorComponents`: added size variants for error body component (icon size, padding, etc)
- `formComponents`: added submit loading swirly on button
- `NotFoundComponent`: added default Page not found component

`components/ui`:
- `skeleton`: updated color slightly to have contrast against default gray background
- `sonner` + `spinner`: checked in new shadcn components

`features`:
- `goals`:
  - `EntryCreatePage`: refactored and moved top bar out of form and up to parent page. Display loading spinner + error body component
  - `GoalCreatePage`: refactored and moved top bar out of form and up to parent page. Display loading skeleton of goal form fields + error body component
  - `GoalDetailsPage`: refactored and moved top bar out of form and up to parent page. Display loading skeleton per block + error body component per block (goal card, stats, chart, etc)
  - `GoalsPage`: removed comment without addressing, since using automatically opened global error toast
- `profile`:
  - `ProfilePage`: Display loading skeletons + error body component per block (profile card, goals)
- `settings`
  - `AccountDetailsPage`: refactored and moved top bar out of form and up to parent page. Display loading spinner + error body component
  - `DeleteAccountPage`: refactored and moved top bar out of form and up to parent page. Display loading spinner + error body component
  - `GoalOrderPage`: removed comment without addressing, since using generic auto error snackbar/ toast
  - `SettingsPage`:  removed comment without addressing, since using generic auto error snackbar/ toast

`hooks`:
- `useSmartBack`: new hook to capture reusable logic of going back via router history, or navigating to a fallback URL

`integrations/tanstack-query`:
- `root-provider`: Added logic to query client `onError` so that upon receiving a status code of 401, it redirects user to /login. Also added logic to open a global error toast whenever a query fails

`routes`:
- `$goalId_.edit`: added pending components i.e. skeleton pages, for SkeletonGoalEditPage
- `create`: as above, with SkeletonGoalCreatepage
- `__root`: updated logic of path-checking so that `isPublicPath` considers whether it's in list OR is the user's own profile path. Also added Tanstack Router default error component (displayed whenever there's an unhandled error)

`root`:
- `main`: added default pending, not found, and error components to Tanstack Router. Added global toast to root render
